### PR TITLE
[#6] feat: Improve entity selection error handling and UI feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
@@ -18,17 +18,18 @@ function App() {
     );
 
     const [showConnectionDialog, setShowConnectionDialog] = useState(false);
+    const autoConnectAttempted = useRef(false);
 
     // Auto-connect on mount if we have a stored URL
     useEffect(() => {
-        if (serverUrl && !isConnected) {
-            Promise.resolve(connect(serverUrl, baseEndpoint))
-                .catch((err) => {
-                    toast.error(
-                        `Auto-connect failed: ${err?.message || 'Please check your server settings.'}`
-                    );
+        if (serverUrl && !isConnected && !autoConnectAttempted.current) {
+            autoConnectAttempted.current = true;
+            connect(serverUrl, baseEndpoint).then((success) => {
+                if (!success) {
+                    toast.error('Auto-connect failed. Please check your server settings.');
                     setShowConnectionDialog(true);
-                });
+                }
+            });
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/src/components/EntityDetailPanel.tsx
+++ b/src/components/EntityDetailPanel.tsx
@@ -55,10 +55,18 @@ export function EntityDetailPanel({ onConnectClick }: EntityDetailPanelProps) {
             return;
         }
 
+        // Parse JSON before setting publishing state to avoid stuck state on parse error
+        let data: unknown;
+        try {
+            data = JSON.parse(inputData);
+        } catch {
+            toast.error('Invalid JSON format. Please check your message data.');
+            return;
+        }
+
         setPublishingTopics(prev => new Set(prev).add(topic.topic));
 
         try {
-            const data = JSON.parse(inputData);
             const messageType = inferMessageType(topic.data);
 
             await client.publishToComponentTopic(selectedEntity.id, topicName, {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -217,16 +217,28 @@ export const useAppStore = create<AppState>()(
         try {
           const details = await client.getEntityDetails(path);
           set({ selectedEntity: details, isLoadingDetails: false });
-        } catch {
-          toast.error(`Failed to load entity details for ${path}`);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Unknown error';
+          toast.error(`Failed to load entity details for ${path}: ${message}`);
 
           // Set fallback entity to allow panel to render
-          const id = path.split('/').pop() || path;
+          // Infer entity type from path structure
+          const segments = path.split('/').filter(Boolean);
+          const id = segments[segments.length - 1] || path;
+          let inferredType: string;
+          if (segments.length === 1) {
+            inferredType = 'area';
+          } else if (segments.length === 2) {
+            inferredType = 'component';
+          } else {
+            inferredType = 'unknown';
+          }
+
           set({
             selectedEntity: {
               id,
               name: id,
-              type: 'component',
+              type: inferredType,
               href: path,
               topics: [],
               error: 'Failed to load details'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,8 @@ export interface SovdEntity {
 export interface SovdEntityDetails extends SovdEntity {
   /** Topics available for this component */
   topics?: ComponentTopic[];
+  /** Error message if fetching details failed */
+  error?: string;
   /** Additional properties vary by entity type */
   [key: string]: unknown;
 }


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to sovd_web_ui! -->

## Summary

- Add toast notification when fetching entity details fails (e.g. timeout)
- Update \`selectEntity\` store action to set a fallback entity with error state instead of clearing selection
- Enhance \`EntityDetailPanel\` to display an error card while preserving the entity header context
- Prevent the UI from reverting to an empty state when a single entity request fails

---

## Issue

- closes #6

---

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

manual testing + npm lint + npm build

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Docs were updated if behavior or public API changed
