### PR TITLE
fix(faults): handle simulation time timestamps in fault display

### DIFF
--- a/src/lib/sovd-api.ts
+++ b/src/lib/sovd-api.ts
@@ -1574,7 +1574,15 @@ export class SovdApiClient {
             message: apiFault.description,
             severity,
             status,
-            timestamp: new Date(apiFault.first_occurred * 1000).toISOString(),
+            // TODO: Remove this workaround after fixing ros2_medkit fault_manager
+            // to use wall clock time instead of sim time for fault timestamps.
+            // See: ros2_medkit/docs/issues/fault-timestamp-sim-time-bug.md
+            // Handle simulation time (small values) vs real Unix timestamps
+            // If timestamp < year 2000, it's likely sim time - use current time instead
+            timestamp:
+                apiFault.first_occurred < 946684800
+                    ? new Date().toISOString()
+                    : new Date(apiFault.first_occurred * 1000).toISOString(),
             entity_id,
             entity_type,
             parameters: {


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to sovd_web_ui! -->

## Summary

When running with use_sim_time=true, fault timestamps are recorded in simulation time (seconds since sim start) instead of Unix epoch. This caused UI to display dates like "1/1/1970 00:02:28".

Detect small timestamps (< year 2000) and substitute current time as a workaround until fault_manager is fixed to use wall clock time.

---

## Issue

Link the related issue (required):

- closes #<issue number>

---

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Docs were updated if behavior or public API changed
