### PR TITLE
chore: remove sim-time timestamp workaround

### DIFF
--- a/src/lib/sovd-api.ts
+++ b/src/lib/sovd-api.ts
@@ -1574,15 +1574,7 @@ export class SovdApiClient {
             message: apiFault.description,
             severity,
             status,
-            // TODO: Remove this workaround after fixing ros2_medkit fault_manager
-            // to use wall clock time instead of sim time for fault timestamps.
-            // See: ros2_medkit/docs/issues/fault-timestamp-sim-time-bug.md
-            // Handle simulation time (small values) vs real Unix timestamps
-            // If timestamp < year 2000, it's likely sim time - use current time instead
-            timestamp:
-                apiFault.first_occurred < 946684800
-                    ? new Date().toISOString()
-                    : new Date(apiFault.first_occurred * 1000).toISOString(),
+            timestamp: new Date(apiFault.first_occurred * 1000).toISOString(),
             entity_id,
             entity_type,
             parameters: {


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to sovd_web_ui! -->

## Summary

The ros2_medkit fault_manager now uses wall clock time for fault timestamps, so the UI workaround for simulation time is no longer needed.
---

## Issue

Link the related issue (required):

- closes #<issue number>

---

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Docs were updated if behavior or public API changed
