### PR TITLE
fix: update VersionInfo type for gateway sovd_info->items rename

### DIFF
--- a/src/components/ServerInfoPanel.tsx
+++ b/src/components/ServerInfoPanel.tsx
@@ -109,7 +109,7 @@ export function ServerInfoPanel() {
     }
 
     // Extract first SOVD info entry for cleaner access
-    const sovdInfo = versionInfo?.sovd_info?.[0];
+    const sovdInfo = versionInfo?.items?.[0];
 
     return (
         <div className="space-y-6">

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -621,7 +621,7 @@ export const useAppStore = create<AppState>()(
                     });
 
                     // Extract server info from version-info response (fallback to generic values if unavailable)
-                    const sovdInfo = versionInfo?.sovd_info?.[0];
+                    const sovdInfo = versionInfo?.items?.[0];
                     const serverName = sovdInfo?.vendor_info?.name || 'SOVD Server';
                     const serverVersion = sovdInfo?.vendor_info?.version || '';
                     const sovdVersion = sovdInfo?.version || '';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -832,7 +832,7 @@ export interface SovdInfoEntry {
  */
 export interface VersionInfo {
     /** Array of SOVD version info entries */
-    sovd_info: SovdInfoEntry[];
+    items: SovdInfoEntry[];
 }
 
 // =============================================================================


### PR DESCRIPTION
# Pull Request

## Summary

The gateway (PR selfpatch/ros2_medkit#258) renamed `GET /version-info` response key from `sovd_info` to `items` for SOVD alignment. This updates the web UI TypeScript types and all consumers to match.

Changes:
- `VersionInfo.sovd_info` -> `VersionInfo.items` in `types.ts`
- Update `store.ts` access pattern: `versionInfo?.sovd_info?.[0]` -> `versionInfo?.items?.[0]`
- Update `ServerInfoPanel.tsx` access pattern

---

## Issue

- closes #39

---

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- `npm run typecheck` passes

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Docs were updated if behavior or public API changed