### PR TITLE
fix: preserve underscores in fault entity_id

### DIFF
--- a/src/lib/transforms.test.ts
+++ b/src/lib/transforms.test.ts
@@ -112,12 +112,12 @@ describe('transformFault', () => {
     describe('entity_id extraction from reporting_sources', () => {
         it('extracts last segment of node path', () => {
             const result = transformFault(makeFaultInput({ reporting_sources: ['/powertrain/engine_monitor'] }));
-            expect(result.entity_id).toBe('engine-monitor');
+            expect(result.entity_id).toBe('engine_monitor');
         });
 
-        it('converts underscores to hyphens in entity_id', () => {
+        it('preserves underscores in entity_id', () => {
             const result = transformFault(makeFaultInput({ reporting_sources: ['/ns/my_node_name'] }));
-            expect(result.entity_id).toBe('my-node-name');
+            expect(result.entity_id).toBe('my_node_name');
         });
 
         it('uses "unknown" when reporting_sources is empty', () => {

--- a/src/lib/transforms.ts
+++ b/src/lib/transforms.ts
@@ -83,7 +83,7 @@ export interface RawFaultItem {
  *   - `severity` (number) + `severity_label` → `severity` (string)
  *   - `status` (CONFIRMED / PREFAILED / ...) → `status` (active / pending / cleared / healed)
  *   - `first_occurred` (unix seconds) → `timestamp` (ISO 8601)
- *   - `reporting_sources[0]` last path segment → `entity_id` (underscores replaced by hyphens)
+ *   - `reporting_sources[0]` last path segment → `entity_id`
  */
 export function transformFault(apiFault: RawFaultItem): Fault {
     // Map severity number/label to FaultSeverity.
@@ -113,11 +113,9 @@ export function transformFault(apiFault: RawFaultItem): Fault {
 
     // Extract entity info from reporting_sources.
     // reporting_sources contains ROS 2 node paths like "/bridge/diagnostic_bridge".
-    // We take the last segment and convert underscores to hyphens to match
-    // the SOVD app ID convention (e.g., "diagnostic_bridge" → "diagnostic-bridge").
+    // We take the last segment as entity_id (preserving underscores - they match SOVD IDs).
     const source = apiFault.reporting_sources?.[0] || '';
-    const nodeName = source.split('/').pop() || 'unknown';
-    const entity_id = nodeName.replace(/_/g, '-');
+    const entity_id = source.split('/').pop() || 'unknown';
 
     // Use entity_type from raw data if provided, otherwise default to 'app'.
     // The gateway's fault_to_json does not currently include entity_type, but


### PR DESCRIPTION
## Summary

`transformFault()` was replacing underscores with hyphens in entity_id extracted from `reporting_sources`. This broke fault detail fetching - FaultsPanel called e.g. `GET /apps/tank-process/faults/...` instead of `/apps/tank_process/faults/...`, getting 404.

## Changes
- `src/lib/transforms.ts`: remove `nodeName.replace(/_/g, '-')` 
- `src/lib/transforms.test.ts`: update expectations to preserve underscores

## Test plan
- [x] 246/246 tests pass
- [x] Verified on real hardware: fault detail with snapshots now loads correctly

Fixes #55
