### PR TITLE
feat: add Software Updates Dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { useSearchShortcut } from '@/hooks/useSearchShortcut';
 import { useAppStore } from '@/lib/store';
 
-type ViewMode = 'entity' | 'faults-dashboard';
+type ViewMode = 'entity' | 'faults-dashboard' | 'updates-dashboard';
 
 function App() {
     const { isConnected, serverUrl, connect, clearSelection, selectedPath } = useAppStore(
@@ -41,6 +41,15 @@ function App() {
         clearSelection();
         setViewMode('faults-dashboard');
         // Close sidebar on mobile when navigating
+        if (window.innerWidth < 768) {
+            setSidebarOpen(false);
+        }
+    }, [clearSelection]);
+
+    // Handle updates dashboard navigation
+    const handleUpdatesDashboardClick = useCallback(() => {
+        clearSelection();
+        setViewMode('updates-dashboard');
         if (window.innerWidth < 768) {
             setSidebarOpen(false);
         }
@@ -109,6 +118,7 @@ function App() {
                         <EntityTreeSidebar
                             onSettingsClick={() => setShowConnectionDialog(true)}
                             onFaultsDashboardClick={handleFaultsDashboardClick}
+                            onUpdatesDashboardClick={handleUpdatesDashboardClick}
                         />
                     </div>
 

--- a/src/components/EntityDetailPanel.tsx
+++ b/src/components/EntityDetailPanel.tsx
@@ -30,6 +30,7 @@ import { AppsPanel } from '@/components/AppsPanel';
 import { FunctionsPanel } from '@/components/FunctionsPanel';
 import { ServerInfoPanel } from '@/components/ServerInfoPanel';
 import { FaultsDashboard } from '@/components/FaultsDashboard';
+import { UpdatesDashboard } from '@/components/UpdatesDashboard';
 import { useAppStore, type AppState } from '@/lib/store';
 import type { ComponentTopic, Parameter, SovdResourceEntityType } from '@/lib/types';
 
@@ -330,7 +331,7 @@ function ParameterDetailCard({ entity, entityId, entityType }: ParameterDetailCa
 
 interface EntityDetailPanelProps {
     onConnectClick: () => void;
-    viewMode?: 'entity' | 'faults-dashboard';
+    viewMode?: 'entity' | 'faults-dashboard' | 'updates-dashboard';
     onEntitySelect?: () => void;
 }
 
@@ -460,6 +461,17 @@ export function EntityDetailPanel({ onConnectClick, viewMode = 'entity', onEntit
             <main className="flex-1 overflow-y-auto p-6 bg-background">
                 <div className="max-w-4xl mx-auto">
                     <FaultsDashboard />
+                </div>
+            </main>
+        );
+    }
+
+    // Updates Dashboard view
+    if (viewMode === 'updates-dashboard' && !selectedPath) {
+        return (
+            <main className="flex-1 overflow-y-auto p-6 bg-background">
+                <div className="max-w-4xl mx-auto">
+                    <UpdatesDashboard />
                 </div>
             </main>
         );

--- a/src/components/EntityTreeSidebar.tsx
+++ b/src/components/EntityTreeSidebar.tsx
@@ -224,25 +224,25 @@ export function EntityTreeSidebar({
 
             {/* Quick Actions */}
             {isConnected && (
-                <div className="p-2 border-t space-y-0.5">
+                <div className="p-2 border-t flex gap-1">
                     <Button
                         variant="ghost"
                         size="sm"
-                        className="w-full justify-start gap-2"
+                        className="flex-1 justify-start gap-2"
                         onClick={onFaultsDashboardClick}
                     >
                         <AlertTriangle className="w-4 h-4 text-amber-500" />
-                        <span>Faults Dashboard</span>
+                        <span>Faults</span>
                         <FaultsCountBadge />
                     </Button>
                     <Button
                         variant="ghost"
                         size="sm"
-                        className="w-full justify-start gap-2"
+                        className="flex-1 justify-start gap-2"
                         onClick={onUpdatesDashboardClick}
                     >
                         <Package className="w-4 h-4 text-blue-500" />
-                        <span>Software Updates</span>
+                        <span>Updates</span>
                     </Button>
                 </div>
             )}

--- a/src/components/EntityTreeSidebar.tsx
+++ b/src/components/EntityTreeSidebar.tsx
@@ -235,15 +235,17 @@ export function EntityTreeSidebar({
                         Faults Dashboard
                         <FaultsCountBadge />
                     </Button>
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        className="flex-1 justify-center gap-1.5 h-8 text-xs"
-                        onClick={onUpdatesDashboardClick}
-                    >
-                        <Package className="w-3.5 h-3.5 text-blue-500" />
-                        Software Updates
-                    </Button>
+                    {onUpdatesDashboardClick && (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="flex-1 justify-center gap-1.5 h-8 text-xs"
+                            onClick={onUpdatesDashboardClick}
+                        >
+                            <Package className="w-3.5 h-3.5 text-blue-500" />
+                            Software Updates
+                        </Button>
+                    )}
                 </div>
             )}
         </aside>

--- a/src/components/EntityTreeSidebar.tsx
+++ b/src/components/EntityTreeSidebar.tsx
@@ -224,25 +224,25 @@ export function EntityTreeSidebar({
 
             {/* Quick Actions */}
             {isConnected && (
-                <div className="p-2 border-t flex gap-1">
+                <div className="px-2 py-1.5 border-t flex gap-1">
                     <Button
                         variant="ghost"
                         size="sm"
-                        className="flex-1 justify-start gap-2"
+                        className="flex-1 justify-center gap-1.5 h-8 text-xs"
                         onClick={onFaultsDashboardClick}
                     >
-                        <AlertTriangle className="w-4 h-4 text-amber-500" />
-                        <span>Faults</span>
+                        <AlertTriangle className="w-3.5 h-3.5 text-amber-500" />
+                        Faults Dashboard
                         <FaultsCountBadge />
                     </Button>
                     <Button
                         variant="ghost"
                         size="sm"
-                        className="flex-1 justify-start gap-2"
+                        className="flex-1 justify-center gap-1.5 h-8 text-xs"
                         onClick={onUpdatesDashboardClick}
                     >
-                        <Package className="w-4 h-4 text-blue-500" />
-                        <span>Updates</span>
+                        <Package className="w-3.5 h-3.5 text-blue-500" />
+                        Software Updates
                     </Button>
                 </div>
             )}

--- a/src/components/EntityTreeSidebar.tsx
+++ b/src/components/EntityTreeSidebar.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
-import { Server, Settings, RefreshCw, Search, X, AlertTriangle, Layers, GitBranch } from 'lucide-react';
+import { Server, Settings, RefreshCw, Search, X, AlertTriangle, Layers, GitBranch, Package } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { EntityTreeNode } from '@/components/EntityTreeNode';
@@ -14,6 +14,7 @@ import type { EntityTreeNode as EntityTreeNodeType } from '@/lib/types';
 interface EntityTreeSidebarProps {
     onSettingsClick: () => void;
     onFaultsDashboardClick?: () => void;
+    onUpdatesDashboardClick?: () => void;
 }
 
 /**
@@ -41,7 +42,11 @@ function filterTree(nodes: EntityTreeNodeType[], query: string): EntityTreeNodeT
     return result;
 }
 
-export function EntityTreeSidebar({ onSettingsClick, onFaultsDashboardClick }: EntityTreeSidebarProps) {
+export function EntityTreeSidebar({
+    onSettingsClick,
+    onFaultsDashboardClick,
+    onUpdatesDashboardClick,
+}: EntityTreeSidebarProps) {
     const [searchQuery, setSearchQuery] = useState('');
     const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -217,9 +222,9 @@ export function EntityTreeSidebar({ onSettingsClick, onFaultsDashboardClick }: E
                 )}
             </div>
 
-            {/* Quick Actions - Faults Dashboard */}
+            {/* Quick Actions */}
             {isConnected && (
-                <div className="p-2 border-t">
+                <div className="p-2 border-t space-y-0.5">
                     <Button
                         variant="ghost"
                         size="sm"
@@ -229,6 +234,15 @@ export function EntityTreeSidebar({ onSettingsClick, onFaultsDashboardClick }: E
                         <AlertTriangle className="w-4 h-4 text-amber-500" />
                         <span>Faults Dashboard</span>
                         <FaultsCountBadge />
+                    </Button>
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className="w-full justify-start gap-2"
+                        onClick={onUpdatesDashboardClick}
+                    >
+                        <Package className="w-4 h-4 text-blue-500" />
+                        <span>Software Updates</span>
                     </Button>
                 </div>
             )}

--- a/src/components/EntityTreeSidebar.tsx
+++ b/src/components/EntityTreeSidebar.tsx
@@ -225,16 +225,18 @@ export function EntityTreeSidebar({
             {/* Quick Actions */}
             {isConnected && (
                 <div className="px-2 py-1.5 border-t flex gap-1">
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        className="flex-1 justify-center gap-1.5 h-8 text-xs"
-                        onClick={onFaultsDashboardClick}
-                    >
-                        <AlertTriangle className="w-3.5 h-3.5 text-amber-500" />
-                        Faults Dashboard
-                        <FaultsCountBadge />
-                    </Button>
+                    {onFaultsDashboardClick && (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            className="flex-1 justify-center gap-1.5 h-8 text-xs"
+                            onClick={onFaultsDashboardClick}
+                        >
+                            <AlertTriangle className="w-3.5 h-3.5 text-amber-500" />
+                            Faults Dashboard
+                            <FaultsCountBadge />
+                        </Button>
+                    )}
                     {onUpdatesDashboardClick && (
                         <Button
                             variant="ghost"

--- a/src/components/UpdateCard.test.tsx
+++ b/src/components/UpdateCard.test.tsx
@@ -30,15 +30,15 @@ describe('UpdateCard', () => {
         expect(screen.getByText(/update-abc-123/)).toBeInTheDocument();
     });
 
-    it('shows loading state when status is null', () => {
+    it('shows status unavailable when status is null', () => {
         const entry: UpdateEntry = {
-            id: 'update-loading',
+            id: 'update-failed-status',
             status: null,
         };
 
         render(<UpdateCard entry={entry} />);
 
-        expect(screen.getByText('Loading...')).toBeInTheDocument();
+        expect(screen.getByText('Status unavailable')).toBeInTheDocument();
     });
 
     it('shows pending badge', () => {

--- a/src/components/UpdateCard.test.tsx
+++ b/src/components/UpdateCard.test.tsx
@@ -1,0 +1,141 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UpdateCard } from './UpdateCard';
+import type { UpdateEntry } from '@/lib/types';
+
+describe('UpdateCard', () => {
+    it('renders update ID', () => {
+        const entry: UpdateEntry = {
+            id: 'update-abc-123',
+            status: { status: 'pending' },
+        };
+
+        render(<UpdateCard entry={entry} />);
+
+        expect(screen.getByText(/update-abc-123/)).toBeInTheDocument();
+    });
+
+    it('shows loading state when status is null', () => {
+        const entry: UpdateEntry = {
+            id: 'update-loading',
+            status: null,
+        };
+
+        render(<UpdateCard entry={entry} />);
+
+        expect(screen.getByText('Loading...')).toBeInTheDocument();
+    });
+
+    it('shows pending badge', () => {
+        const entry: UpdateEntry = {
+            id: 'update-pending',
+            status: { status: 'pending' },
+        };
+
+        render(<UpdateCard entry={entry} />);
+
+        expect(screen.getByText('pending')).toBeInTheDocument();
+    });
+
+    it('shows inProgress badge with progress bar', () => {
+        const entry: UpdateEntry = {
+            id: 'update-inprogress',
+            status: { status: 'inProgress', progress: 42 },
+        };
+
+        render(<UpdateCard entry={entry} />);
+
+        expect(screen.getByText('inProgress')).toBeInTheDocument();
+        const progressBar = screen.getByRole('progressbar');
+        expect(progressBar).toBeInTheDocument();
+        expect(progressBar).toHaveAttribute('aria-valuenow', '42');
+        expect(progressBar).toHaveAttribute('aria-valuemin', '0');
+        expect(progressBar).toHaveAttribute('aria-valuemax', '100');
+    });
+
+    it('shows completed badge', () => {
+        const entry: UpdateEntry = {
+            id: 'update-done',
+            status: { status: 'completed' },
+        };
+
+        render(<UpdateCard entry={entry} />);
+
+        expect(screen.getByText('completed')).toBeInTheDocument();
+    });
+
+    it('shows failed badge with error message text', () => {
+        const entry: UpdateEntry = {
+            id: 'update-failed',
+            status: { status: 'failed', error: 'Checksum verification failed' },
+        };
+
+        render(<UpdateCard entry={entry} />);
+
+        expect(screen.getByText('failed')).toBeInTheDocument();
+        expect(screen.getByText('Checksum verification failed')).toBeInTheDocument();
+    });
+
+    it('shows sub-progress list when present', () => {
+        const entry: UpdateEntry = {
+            id: 'update-sub',
+            status: {
+                status: 'inProgress',
+                progress: 60,
+                sub_progress: [
+                    { name: 'Download', progress: 100 },
+                    { name: 'Verify', progress: 20 },
+                ],
+            },
+        };
+
+        render(<UpdateCard entry={entry} />);
+
+        expect(screen.getByText('Download')).toBeInTheDocument();
+        expect(screen.getByText('100%')).toBeInTheDocument();
+        expect(screen.getByText('Verify')).toBeInTheDocument();
+        expect(screen.getByText('20%')).toBeInTheDocument();
+    });
+
+    it('does not show progress bar when progress is undefined', () => {
+        const entry: UpdateEntry = {
+            id: 'update-no-progress',
+            status: { status: 'pending' },
+        };
+
+        render(<UpdateCard entry={entry} />);
+
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+
+    it('calls onAction with correct id and action when action button clicked', async () => {
+        const user = userEvent.setup();
+        const onAction = vi.fn();
+        const entry: UpdateEntry = {
+            id: 'update-act',
+            status: { status: 'pending' },
+        };
+
+        render(<UpdateCard entry={entry} onAction={onAction} />);
+
+        const prepareButton = screen.getByRole('button', { name: /prepare/i });
+        await user.click(prepareButton);
+
+        expect(onAction).toHaveBeenCalledWith('update-act', 'prepare');
+    });
+});

--- a/src/components/UpdateCard.tsx
+++ b/src/components/UpdateCard.tsx
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { useState, useCallback } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Package, Loader2, AlertCircle } from 'lucide-react';
+import { Package, Loader2, AlertCircle, FileText } from 'lucide-react';
+import { fetchUpdateDetail } from '@/lib/updates-api';
 import type { UpdateEntry, UpdateStatusValue } from '@/lib/types';
 
 export type UpdateAction = 'prepare' | 'execute' | 'automated' | 'delete';
 
 interface UpdateCardProps {
     entry: UpdateEntry;
+    baseUrl?: string | null;
     onAction?: (id: string, action: UpdateAction) => void;
 }
 
@@ -56,13 +60,13 @@ function progressBarColor(status: UpdateStatusValue): string {
 function actionButtonsForStatus(status: UpdateStatusValue): UpdateAction[] {
     switch (status) {
         case 'pending':
-            return ['prepare', 'automated', 'delete'];
+            return ['prepare', 'execute', 'automated', 'delete'];
         case 'inProgress':
             return [];
         case 'completed':
             return ['delete'];
         case 'failed':
-            return ['prepare', 'delete'];
+            return ['prepare', 'execute', 'delete'];
     }
 }
 
@@ -79,8 +83,25 @@ function actionLabel(action: UpdateAction): string {
     }
 }
 
-export function UpdateCard({ entry, onAction }: UpdateCardProps) {
+export function UpdateCard({ entry, baseUrl, onAction }: UpdateCardProps) {
     const { id, status } = entry;
+    const [detailOpen, setDetailOpen] = useState(false);
+    const [detail, setDetail] = useState<Record<string, unknown> | null>(null);
+    const [detailLoading, setDetailLoading] = useState(false);
+
+    const handleViewDetails = useCallback(async () => {
+        if (!baseUrl) return;
+        setDetailOpen(true);
+        setDetailLoading(true);
+        try {
+            const data = await fetchUpdateDetail(baseUrl, id);
+            setDetail(data);
+        } catch {
+            setDetail({ error: 'Failed to load details' });
+        } finally {
+            setDetailLoading(false);
+        }
+    }, [baseUrl, id]);
 
     const isFailed = status?.status === 'failed';
 
@@ -145,9 +166,9 @@ export function UpdateCard({ entry, onAction }: UpdateCardProps) {
                             </div>
                         )}
 
-                        {onAction && (
-                            <div className="flex flex-wrap gap-2 pt-1">
-                                {actionButtonsForStatus(status.status).map((action) => (
+                        <div className="flex flex-wrap gap-2 pt-1">
+                            {onAction &&
+                                actionButtonsForStatus(status.status).map((action) => (
                                     <Button
                                         key={action}
                                         size="sm"
@@ -157,11 +178,34 @@ export function UpdateCard({ entry, onAction }: UpdateCardProps) {
                                         {actionLabel(action)}
                                     </Button>
                                 ))}
-                            </div>
-                        )}
+                            {baseUrl && (
+                                <Button size="sm" variant="ghost" onClick={handleViewDetails}>
+                                    <FileText className="h-3.5 w-3.5 mr-1" />
+                                    Details
+                                </Button>
+                            )}
+                        </div>
                     </>
                 )}
             </CardContent>
+
+            <Dialog open={detailOpen} onOpenChange={setDetailOpen}>
+                <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
+                    <DialogHeader>
+                        <DialogTitle>Update: {id}</DialogTitle>
+                    </DialogHeader>
+                    {detailLoading ? (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            Loading details...
+                        </div>
+                    ) : (
+                        <pre className="text-xs bg-muted rounded-md p-3 overflow-x-auto whitespace-pre-wrap">
+                            {JSON.stringify(detail, null, 2)}
+                        </pre>
+                    )}
+                </DialogContent>
+            </Dialog>
         </Card>
     );
 }

--- a/src/components/UpdateCard.tsx
+++ b/src/components/UpdateCard.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
@@ -88,20 +88,38 @@ export function UpdateCard({ entry, baseUrl, onAction }: UpdateCardProps) {
     const [detailOpen, setDetailOpen] = useState(false);
     const [detail, setDetail] = useState<Record<string, unknown> | null>(null);
     const [detailLoading, setDetailLoading] = useState(false);
+    const detailAbortRef = useRef<AbortController | null>(null);
 
     const handleViewDetails = useCallback(async () => {
         if (!baseUrl) return;
+        detailAbortRef.current?.abort();
+        const controller = new AbortController();
+        detailAbortRef.current = controller;
+        setDetail(null);
         setDetailOpen(true);
         setDetailLoading(true);
         try {
-            const data = await fetchUpdateDetail(baseUrl, id);
-            setDetail(data);
+            const data = await fetchUpdateDetail(baseUrl, id, controller.signal);
+            if (!controller.signal.aborted) {
+                setDetail(data);
+            }
         } catch {
-            setDetail({ error: 'Failed to load details' });
+            if (!controller.signal.aborted) {
+                setDetail({ error: 'Failed to load details' });
+            }
         } finally {
-            setDetailLoading(false);
+            if (!controller.signal.aborted) {
+                setDetailLoading(false);
+            }
         }
     }, [baseUrl, id]);
+
+    const handleDetailClose = useCallback((open: boolean) => {
+        if (!open) {
+            detailAbortRef.current?.abort();
+        }
+        setDetailOpen(open);
+    }, []);
 
     const isFailed = status?.status === 'failed';
 
@@ -189,7 +207,7 @@ export function UpdateCard({ entry, baseUrl, onAction }: UpdateCardProps) {
                 )}
             </CardContent>
 
-            <Dialog open={detailOpen} onOpenChange={setDetailOpen}>
+            <Dialog open={detailOpen} onOpenChange={handleDetailClose}>
                 <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto">
                     <DialogHeader>
                         <DialogTitle>Update: {id}</DialogTitle>

--- a/src/components/UpdateCard.tsx
+++ b/src/components/UpdateCard.tsx
@@ -1,0 +1,167 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Package, Loader2, AlertCircle } from 'lucide-react';
+import type { UpdateEntry, UpdateStatusValue } from '@/lib/types';
+
+export type UpdateAction = 'prepare' | 'execute' | 'automated' | 'delete';
+
+interface UpdateCardProps {
+    entry: UpdateEntry;
+    onAction?: (id: string, action: UpdateAction) => void;
+}
+
+type BadgeVariant = 'outline' | 'default' | 'secondary' | 'destructive';
+
+function statusBadgeVariant(status: UpdateStatusValue): BadgeVariant {
+    switch (status) {
+        case 'pending':
+            return 'outline';
+        case 'inProgress':
+            return 'default';
+        case 'completed':
+            return 'secondary';
+        case 'failed':
+            return 'destructive';
+    }
+}
+
+function progressBarColor(status: UpdateStatusValue): string {
+    switch (status) {
+        case 'inProgress':
+            return 'bg-blue-500';
+        case 'completed':
+            return 'bg-green-500';
+        case 'failed':
+            return 'bg-red-500';
+        default:
+            return 'bg-gray-400';
+    }
+}
+
+function actionButtonsForStatus(status: UpdateStatusValue): UpdateAction[] {
+    switch (status) {
+        case 'pending':
+            return ['prepare', 'automated', 'delete'];
+        case 'inProgress':
+            return [];
+        case 'completed':
+            return ['delete'];
+        case 'failed':
+            return ['prepare', 'delete'];
+    }
+}
+
+function actionLabel(action: UpdateAction): string {
+    switch (action) {
+        case 'prepare':
+            return 'Prepare';
+        case 'execute':
+            return 'Execute';
+        case 'automated':
+            return 'Automated';
+        case 'delete':
+            return 'Delete';
+    }
+}
+
+export function UpdateCard({ entry, onAction }: UpdateCardProps) {
+    const { id, status } = entry;
+
+    const isFailed = status?.status === 'failed';
+
+    return (
+        <Card className={isFailed ? 'border-red-300 dark:border-red-800' : undefined}>
+            <CardHeader className="py-3 px-4">
+                <div className="flex items-center justify-between gap-2">
+                    <CardTitle className="text-sm font-medium flex items-center gap-2 min-w-0">
+                        <Package className="h-4 w-4 shrink-0" />
+                        <span className="truncate">{id}</span>
+                    </CardTitle>
+                    {status && <Badge variant={statusBadgeVariant(status.status)}>{status.status}</Badge>}
+                </div>
+            </CardHeader>
+
+            <CardContent className="py-2 px-4 space-y-3">
+                {status === null && (
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        <span>Loading...</span>
+                    </div>
+                )}
+
+                {status !== null && status !== undefined && (
+                    <>
+                        {status.progress !== undefined && (
+                            <div
+                                role="progressbar"
+                                aria-valuenow={status.progress}
+                                aria-valuemin={0}
+                                aria-valuemax={100}
+                                className="w-full h-2 rounded-full bg-muted overflow-hidden"
+                            >
+                                <div
+                                    className={`h-full ${progressBarColor(status.status)} transition-all`}
+                                    style={{ width: `${status.progress}%` }}
+                                />
+                            </div>
+                        )}
+
+                        {status.sub_progress && status.sub_progress.length > 0 && (
+                            <ul className="space-y-1">
+                                {status.sub_progress.map((sub) => (
+                                    <li key={sub.name} className="flex items-center gap-2 text-xs">
+                                        <span className="w-24 shrink-0 text-muted-foreground truncate">{sub.name}</span>
+                                        <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
+                                            <div
+                                                className={`h-full ${progressBarColor(status.status)}`}
+                                                style={{ width: `${sub.progress}%` }}
+                                            />
+                                        </div>
+                                        <span className="w-9 text-right tabular-nums">{sub.progress}%</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+
+                        {status.error && (
+                            <div className="flex items-start gap-2 text-sm text-red-600 dark:text-red-400">
+                                <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                                <span>{status.error}</span>
+                            </div>
+                        )}
+
+                        {onAction && (
+                            <div className="flex flex-wrap gap-2 pt-1">
+                                {actionButtonsForStatus(status.status).map((action) => (
+                                    <Button
+                                        key={action}
+                                        size="sm"
+                                        variant={action === 'delete' ? 'destructive' : 'outline'}
+                                        onClick={() => onAction(id, action)}
+                                    >
+                                        {actionLabel(action)}
+                                    </Button>
+                                ))}
+                            </div>
+                        )}
+                    </>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/components/UpdateCard.tsx
+++ b/src/components/UpdateCard.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
@@ -121,6 +121,12 @@ export function UpdateCard({ entry, baseUrl, onAction }: UpdateCardProps) {
         setDetailOpen(open);
     }, []);
 
+    useEffect(() => {
+        return () => {
+            detailAbortRef.current?.abort();
+        };
+    }, []);
+
     const isFailed = status?.status === 'failed';
 
     return (
@@ -137,9 +143,9 @@ export function UpdateCard({ entry, baseUrl, onAction }: UpdateCardProps) {
 
             <CardContent className="py-2 px-4 space-y-3">
                 {status === null && (
-                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        <span>Loading...</span>
+                    <div className="flex items-start gap-2 text-sm text-muted-foreground">
+                        <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                        <span>Status unavailable</span>
                     </div>
                 )}
 
@@ -148,6 +154,7 @@ export function UpdateCard({ entry, baseUrl, onAction }: UpdateCardProps) {
                         {status.progress !== undefined && (
                             <div
                                 role="progressbar"
+                                aria-label={`Progress for update ${id}`}
                                 aria-valuenow={status.progress}
                                 aria-valuemin={0}
                                 aria-valuemax={100}

--- a/src/components/UpdateCard.tsx
+++ b/src/components/UpdateCard.tsx
@@ -26,6 +26,7 @@ export type UpdateAction = 'prepare' | 'execute' | 'automated' | 'delete';
 interface UpdateCardProps {
     entry: UpdateEntry;
     baseUrl?: string | null;
+    busy?: boolean;
     onAction?: (id: string, action: UpdateAction) => void;
 }
 
@@ -70,6 +71,10 @@ function actionButtonsForStatus(status: UpdateStatusValue): UpdateAction[] {
     }
 }
 
+function clampProgress(value: number): number {
+    return Math.min(100, Math.max(0, value));
+}
+
 function actionLabel(action: UpdateAction): string {
     switch (action) {
         case 'prepare':
@@ -83,7 +88,7 @@ function actionLabel(action: UpdateAction): string {
     }
 }
 
-export function UpdateCard({ entry, baseUrl, onAction }: UpdateCardProps) {
+export function UpdateCard({ entry, baseUrl, busy, onAction }: UpdateCardProps) {
     const { id, status } = entry;
     const [detailOpen, setDetailOpen] = useState(false);
     const [detail, setDetail] = useState<Record<string, unknown> | null>(null);
@@ -151,21 +156,25 @@ export function UpdateCard({ entry, baseUrl, onAction }: UpdateCardProps) {
 
                 {status !== null && status !== undefined && (
                     <>
-                        {status.progress !== undefined && (
-                            <div
-                                role="progressbar"
-                                aria-label={`Progress for update ${id}`}
-                                aria-valuenow={status.progress}
-                                aria-valuemin={0}
-                                aria-valuemax={100}
-                                className="w-full h-2 rounded-full bg-muted overflow-hidden"
-                            >
-                                <div
-                                    className={`h-full ${progressBarColor(status.status)} transition-all`}
-                                    style={{ width: `${status.progress}%` }}
-                                />
-                            </div>
-                        )}
+                        {status.progress !== undefined &&
+                            (() => {
+                                const clamped = clampProgress(status.progress);
+                                return (
+                                    <div
+                                        role="progressbar"
+                                        aria-label={`Progress for update ${id}`}
+                                        aria-valuenow={clamped}
+                                        aria-valuemin={0}
+                                        aria-valuemax={100}
+                                        className="w-full h-2 rounded-full bg-muted overflow-hidden"
+                                    >
+                                        <div
+                                            className={`h-full ${progressBarColor(status.status)} transition-all`}
+                                            style={{ width: `${clamped}%` }}
+                                        />
+                                    </div>
+                                );
+                            })()}
 
                         {status.sub_progress && status.sub_progress.length > 0 && (
                             <ul className="space-y-1">
@@ -175,10 +184,12 @@ export function UpdateCard({ entry, baseUrl, onAction }: UpdateCardProps) {
                                         <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
                                             <div
                                                 className={`h-full ${progressBarColor(status.status)}`}
-                                                style={{ width: `${sub.progress}%` }}
+                                                style={{ width: `${clampProgress(sub.progress)}%` }}
                                             />
                                         </div>
-                                        <span className="w-9 text-right tabular-nums">{sub.progress}%</span>
+                                        <span className="w-9 text-right tabular-nums">
+                                            {clampProgress(sub.progress)}%
+                                        </span>
                                     </li>
                                 ))}
                             </ul>
@@ -198,6 +209,7 @@ export function UpdateCard({ entry, baseUrl, onAction }: UpdateCardProps) {
                                         key={action}
                                         size="sm"
                                         variant={action === 'delete' ? 'destructive' : 'outline'}
+                                        disabled={busy}
                                         onClick={() => onAction(id, action)}
                                     >
                                         {actionLabel(action)}

--- a/src/components/UpdatesDashboard.test.tsx
+++ b/src/components/UpdatesDashboard.test.tsx
@@ -45,6 +45,23 @@ vi.mock('react-toastify', () => ({
     },
 }));
 
+const mockTriggerPrepare = vi.fn();
+const mockDeleteUpdate = vi.fn();
+
+vi.mock('@/lib/updates-api', () => ({
+    triggerPrepare: (...args: unknown[]) => mockTriggerPrepare(...args),
+    triggerExecute: vi.fn(),
+    triggerAutomated: vi.fn(),
+    deleteUpdate: (...args: unknown[]) => mockDeleteUpdate(...args),
+    UpdatesApiError: class extends Error {
+        readonly status: number;
+        constructor(message: string, status: number) {
+            super(message);
+            this.status = status;
+        }
+    },
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -56,6 +73,7 @@ function makeResult(overrides: Partial<UseUpdatesPollingResult> = {}): UseUpdate
         error: null,
         notAvailable: false,
         refresh: vi.fn(),
+        effectiveInterval: 5000,
         ...overrides,
     };
 }
@@ -149,5 +167,36 @@ describe('UpdatesDashboard', () => {
         render(<UpdatesDashboard />);
 
         expect(screen.getByText(/Network timeout/)).toBeInTheDocument();
+    });
+
+    it('shows toast on successful action', async () => {
+        const user = userEvent.setup();
+        const refresh = vi.fn();
+        mockTriggerPrepare.mockResolvedValue(undefined);
+        mockUseUpdatesPolling.mockReturnValue(makeResult({ updates: [makeEntry('fw-v2', 'pending')], refresh }));
+        const { toast } = await import('react-toastify');
+
+        render(<UpdatesDashboard />);
+
+        const prepareBtn = screen.getByRole('button', { name: /prepare/i });
+        await user.click(prepareBtn);
+
+        expect(mockTriggerPrepare).toHaveBeenCalled();
+        expect(toast.success).toHaveBeenCalled();
+        expect(refresh).toHaveBeenCalled();
+    });
+
+    it('shows toast on failed action', async () => {
+        const user = userEvent.setup();
+        mockTriggerPrepare.mockRejectedValue(new Error('Update in progress'));
+        mockUseUpdatesPolling.mockReturnValue(makeResult({ updates: [makeEntry('fw-v2', 'pending')] }));
+        const { toast } = await import('react-toastify');
+
+        render(<UpdatesDashboard />);
+
+        const prepareBtn = screen.getByRole('button', { name: /prepare/i });
+        await user.click(prepareBtn);
+
+        expect(toast.error).toHaveBeenCalled();
     });
 });

--- a/src/components/UpdatesDashboard.test.tsx
+++ b/src/components/UpdatesDashboard.test.tsx
@@ -1,0 +1,153 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { UseUpdatesPollingResult } from '@/hooks/useUpdatesPolling';
+import type { UpdateEntry } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockUseUpdatesPolling = vi.fn<() => UseUpdatesPollingResult>();
+
+vi.mock('@/hooks/useUpdatesPolling', () => ({
+    useUpdatesPolling: () => mockUseUpdatesPolling(),
+}));
+
+vi.mock('@/lib/store', () => ({
+    useAppStore: vi.fn((selector: (s: { serverUrl: string; isConnected: boolean }) => unknown) =>
+        selector({
+            serverUrl: 'http://localhost:8080',
+            isConnected: true,
+        })
+    ),
+}));
+
+// toast is used by the component but we don't need real notifications in tests
+vi.mock('react-toastify', () => ({
+    toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeResult(overrides: Partial<UseUpdatesPollingResult> = {}): UseUpdatesPollingResult {
+    return {
+        updates: [],
+        isLoading: false,
+        error: null,
+        notAvailable: false,
+        refresh: vi.fn(),
+        ...overrides,
+    };
+}
+
+function makeEntry(
+    id: string,
+    statusValue: 'pending' | 'inProgress' | 'completed' | 'failed' = 'pending'
+): UpdateEntry {
+    return {
+        id,
+        status: { status: statusValue },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Lazy import to ensure mocks are set up before the module is loaded
+const { UpdatesDashboard } = await import('./UpdatesDashboard');
+
+describe('UpdatesDashboard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('shows loading state initially', () => {
+        mockUseUpdatesPolling.mockReturnValue(makeResult({ isLoading: true, updates: [] }));
+
+        render(<UpdatesDashboard />);
+
+        expect(screen.getByText(/loading updates/i)).toBeInTheDocument();
+    });
+
+    it('shows empty state when no updates', () => {
+        mockUseUpdatesPolling.mockReturnValue(makeResult({ isLoading: false, updates: [] }));
+
+        render(<UpdatesDashboard />);
+
+        expect(screen.getByText(/no software updates/i)).toBeInTheDocument();
+    });
+
+    it('shows not available state on 501', () => {
+        mockUseUpdatesPolling.mockReturnValue(makeResult({ notAvailable: true }));
+
+        render(<UpdatesDashboard />);
+
+        expect(screen.getByText(/not available/i)).toBeInTheDocument();
+    });
+
+    it('renders grid of UpdateCards', () => {
+        const updates = [makeEntry('firmware-v2.1.0'), makeEntry('kernel-patch-42')];
+        mockUseUpdatesPolling.mockReturnValue(makeResult({ updates }));
+
+        render(<UpdatesDashboard />);
+
+        expect(screen.getByText('firmware-v2.1.0')).toBeInTheDocument();
+        expect(screen.getByText('kernel-patch-42')).toBeInTheDocument();
+    });
+
+    it('shows correct summary counts', () => {
+        const updates = [
+            makeEntry('update-1', 'pending'),
+            makeEntry('update-2', 'inProgress'),
+            makeEntry('update-3', 'failed'),
+        ];
+        mockUseUpdatesPolling.mockReturnValue(makeResult({ updates }));
+
+        render(<UpdatesDashboard />);
+
+        expect(screen.getByText(/2 active/i)).toBeInTheDocument();
+        expect(screen.getByText(/1 failed/i)).toBeInTheDocument();
+    });
+
+    it('refresh button triggers refetch', async () => {
+        const user = userEvent.setup();
+        const refresh = vi.fn();
+        mockUseUpdatesPolling.mockReturnValue(makeResult({ refresh }));
+
+        render(<UpdatesDashboard />);
+
+        const refreshButton = screen.getByRole('button', { name: /refresh updates/i });
+        await user.click(refreshButton);
+
+        expect(refresh).toHaveBeenCalledOnce();
+    });
+
+    it('shows error state with error message', () => {
+        mockUseUpdatesPolling.mockReturnValue(makeResult({ error: 'Network timeout' }));
+
+        render(<UpdatesDashboard />);
+
+        expect(screen.getByText(/Network timeout/)).toBeInTheDocument();
+    });
+});

--- a/src/components/UpdatesDashboard.tsx
+++ b/src/components/UpdatesDashboard.tsx
@@ -1,0 +1,161 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useCallback, useMemo } from 'react';
+import { useShallow } from 'zustand/shallow';
+import { Package, RefreshCw, AlertTriangle, Loader2 } from 'lucide-react';
+import { toast } from 'react-toastify';
+import { normalizeBaseUrl } from '@selfpatch/ros2-medkit-client-ts';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { UpdateCard, type UpdateAction } from '@/components/UpdateCard';
+import { useUpdatesPolling } from '@/hooks/useUpdatesPolling';
+import { triggerPrepare, triggerExecute, triggerAutomated, deleteUpdate } from '@/lib/updates-api';
+import { useAppStore } from '@/lib/store';
+
+export function UpdatesDashboard() {
+    const { serverUrl, isConnected } = useAppStore(
+        useShallow((state) => ({
+            serverUrl: state.serverUrl,
+            isConnected: state.isConnected,
+        }))
+    );
+
+    const baseUrl = isConnected && serverUrl ? normalizeBaseUrl(serverUrl) : null;
+
+    const { updates, isLoading, error, notAvailable, refresh } = useUpdatesPolling(baseUrl);
+
+    const summary = useMemo(() => {
+        let active = 0;
+        let failed = 0;
+        let completed = 0;
+        for (const u of updates) {
+            if (!u.status) continue;
+            if (u.status.status === 'pending' || u.status.status === 'inProgress') active++;
+            else if (u.status.status === 'failed') failed++;
+            else if (u.status.status === 'completed') completed++;
+        }
+        return { active, failed, completed };
+    }, [updates]);
+
+    const handleAction = useCallback(
+        async (id: string, action: UpdateAction) => {
+            if (!baseUrl) return;
+            try {
+                if (action === 'prepare') await triggerPrepare(baseUrl, id);
+                else if (action === 'execute') await triggerExecute(baseUrl, id);
+                else if (action === 'automated') await triggerAutomated(baseUrl, id);
+                else if (action === 'delete') await deleteUpdate(baseUrl, id);
+                toast.success(`${action} triggered for ${id}`);
+                refresh();
+            } catch (err) {
+                toast.error(err instanceof Error ? err.message : String(err));
+            }
+        },
+        [baseUrl, refresh]
+    );
+
+    const header = (
+        <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center gap-3">
+                <Package className="h-5 w-5 text-muted-foreground" />
+                <h2 className="text-lg font-semibold">Software Updates</h2>
+                {summary.active > 0 && <Badge variant="default">{summary.active} active</Badge>}
+                {summary.failed > 0 && <Badge variant="destructive">{summary.failed} failed</Badge>}
+                {summary.completed > 0 && <Badge variant="secondary">{summary.completed} completed</Badge>}
+            </div>
+            <Button variant="outline" size="sm" aria-label="Refresh updates" onClick={refresh}>
+                <RefreshCw className="h-4 w-4" />
+            </Button>
+        </div>
+    );
+
+    if (isLoading && updates.length === 0) {
+        return (
+            <div>
+                {header}
+                <div className="grid gap-4 md:grid-cols-2">
+                    {Array.from({ length: 4 }).map((_, i) => (
+                        <Skeleton key={i} className="h-32 w-full rounded-lg" />
+                    ))}
+                </div>
+                <p className="mt-4 text-sm text-center text-muted-foreground">loading updates...</p>
+            </div>
+        );
+    }
+
+    if (notAvailable) {
+        return (
+            <div>
+                {header}
+                <Card>
+                    <CardContent className="pt-6">
+                        <div className="flex flex-col items-center justify-center py-8 text-center text-muted-foreground">
+                            <AlertTriangle className="h-10 w-10 mb-3 opacity-50" />
+                            <p className="font-medium">Software updates not available on this gateway</p>
+                            <p className="text-sm mt-1">The gateway does not support the updates API (501).</p>
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div>
+                {header}
+                <Card>
+                    <CardContent className="pt-6">
+                        <div className="flex flex-col items-center justify-center py-8 text-center text-destructive">
+                            <AlertTriangle className="h-10 w-10 mb-3" />
+                            <p className="font-medium">Failed to load updates</p>
+                            <p className="text-sm mt-1">{error}</p>
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        );
+    }
+
+    if (updates.length === 0) {
+        return (
+            <div>
+                {header}
+                <Card>
+                    <CardContent className="pt-6">
+                        <div className="flex flex-col items-center justify-center py-8 text-center text-muted-foreground">
+                            <Loader2 className="h-10 w-10 mb-3 opacity-30" />
+                            <p className="font-medium">No software updates registered</p>
+                            <p className="text-sm mt-1">Updates appear here once the gateway reports them.</p>
+                        </div>
+                    </CardContent>
+                </Card>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            {header}
+            <div className="grid gap-4 md:grid-cols-2">
+                {updates.map((entry) => (
+                    <UpdateCard key={entry.id} entry={entry} onAction={handleAction} />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/UpdatesDashboard.tsx
+++ b/src/components/UpdatesDashboard.tsx
@@ -14,7 +14,7 @@
 
 import { useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
-import { Package, RefreshCw, AlertTriangle } from 'lucide-react';
+import { Package, RefreshCw, AlertTriangle, Server } from 'lucide-react';
 import { toast } from 'react-toastify';
 import { normalizeBaseUrl } from '@selfpatch/ros2-medkit-client-ts';
 import { Card, CardContent } from '@/components/ui/card';
@@ -86,6 +86,16 @@ export function UpdatesDashboard() {
             </Button>
         </div>
     );
+
+    if (!isConnected) {
+        return (
+            <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
+                <Server className="h-10 w-10 mb-3 opacity-50" />
+                <p className="font-medium">Not connected</p>
+                <p className="text-sm mt-1">Connect to a gateway to view software updates.</p>
+            </div>
+        );
+    }
 
     if (isLoading && updates.length === 0) {
         return (

--- a/src/components/UpdatesDashboard.tsx
+++ b/src/components/UpdatesDashboard.tsx
@@ -54,6 +54,10 @@ export function UpdatesDashboard() {
     const handleAction = useCallback(
         async (id: string, action: UpdateAction) => {
             if (!baseUrl) return;
+            if (action === 'delete') {
+                const confirmed = window.confirm(`Delete update "${id}"? This cannot be undone.`);
+                if (!confirmed) return;
+            }
             try {
                 if (action === 'prepare') await triggerPrepare(baseUrl, id);
                 else if (action === 'execute') await triggerExecute(baseUrl, id);

--- a/src/components/UpdatesDashboard.tsx
+++ b/src/components/UpdatesDashboard.tsx
@@ -14,7 +14,7 @@
 
 import { useCallback, useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
-import { Package, RefreshCw, AlertTriangle, Loader2 } from 'lucide-react';
+import { Package, RefreshCw, AlertTriangle } from 'lucide-react';
 import { toast } from 'react-toastify';
 import { normalizeBaseUrl } from '@selfpatch/ros2-medkit-client-ts';
 import { Card, CardContent } from '@/components/ui/card';
@@ -142,7 +142,7 @@ export function UpdatesDashboard() {
                 <Card>
                     <CardContent className="pt-6">
                         <div className="flex flex-col items-center justify-center py-8 text-center text-muted-foreground">
-                            <Loader2 className="h-10 w-10 mb-3 opacity-30" />
+                            <Package className="h-10 w-10 mb-3 opacity-30" />
                             <p className="font-medium">No software updates registered</p>
                             <p className="text-sm mt-1">Updates appear here once the gateway reports them.</p>
                         </div>
@@ -157,7 +157,7 @@ export function UpdatesDashboard() {
             {header}
             <div className="grid gap-4 md:grid-cols-2">
                 {updates.map((entry) => (
-                    <UpdateCard key={entry.id} entry={entry} onAction={handleAction} />
+                    <UpdateCard key={entry.id} entry={entry} baseUrl={baseUrl} onAction={handleAction} />
                 ))}
             </div>
         </div>

--- a/src/components/UpdatesDashboard.tsx
+++ b/src/components/UpdatesDashboard.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useCallback, useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { Package, RefreshCw, AlertTriangle, Server } from 'lucide-react';
 import { toast } from 'react-toastify';
@@ -37,6 +37,7 @@ export function UpdatesDashboard() {
     const baseUrl = isConnected && serverUrl ? normalizeBaseUrl(serverUrl) : null;
 
     const { updates, isLoading, error, notAvailable, refresh } = useUpdatesPolling(baseUrl);
+    const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
 
     const summary = useMemo(() => {
         let active = 0;
@@ -58,6 +59,7 @@ export function UpdatesDashboard() {
                 const confirmed = window.confirm(`Delete update "${id}"? This cannot be undone.`);
                 if (!confirmed) return;
             }
+            setBusyIds((prev) => new Set(prev).add(id));
             try {
                 if (action === 'prepare') await triggerPrepare(baseUrl, id);
                 else if (action === 'execute') await triggerExecute(baseUrl, id);
@@ -67,6 +69,12 @@ export function UpdatesDashboard() {
                 refresh();
             } catch (err) {
                 toast.error(err instanceof Error ? err.message : String(err));
+            } finally {
+                setBusyIds((prev) => {
+                    const next = new Set(prev);
+                    next.delete(id);
+                    return next;
+                });
             }
         },
         [baseUrl, refresh]
@@ -167,7 +175,13 @@ export function UpdatesDashboard() {
             {header}
             <div className="grid gap-4 md:grid-cols-2">
                 {updates.map((entry) => (
-                    <UpdateCard key={entry.id} entry={entry} baseUrl={baseUrl} onAction={handleAction} />
+                    <UpdateCard
+                        key={entry.id}
+                        entry={entry}
+                        baseUrl={baseUrl}
+                        busy={busyIds.has(entry.id)}
+                        onAction={handleAction}
+                    />
                 ))}
             </div>
         </div>

--- a/src/hooks/useUpdatesPolling.test.ts
+++ b/src/hooks/useUpdatesPolling.test.ts
@@ -1,0 +1,323 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useUpdatesPolling } from './useUpdatesPolling';
+import type { UpdateStatus } from '@/lib/types';
+
+vi.mock('@/lib/updates-api', async (importOriginal) => {
+    const original = await importOriginal<typeof import('@/lib/updates-api')>();
+    return {
+        ...original,
+        fetchUpdateIds: vi.fn(),
+        fetchUpdateStatus: vi.fn(),
+    };
+});
+
+const { fetchUpdateIds, fetchUpdateStatus, UpdatesApiError } = await import('@/lib/updates-api');
+const mockFetchUpdateIds = vi.mocked(fetchUpdateIds);
+const mockFetchUpdateStatus = vi.mocked(fetchUpdateStatus);
+
+const BASE_URL = 'http://localhost:8080/api/v1';
+const DEFAULT_INTERVAL = 2000;
+
+const STATUS_PENDING: UpdateStatus = { status: 'pending' };
+const STATUS_IN_PROGRESS: UpdateStatus = { status: 'inProgress', progress: 42 };
+
+describe('useUpdatesPolling', () => {
+    beforeEach(() => {
+        vi.useFakeTimers({ shouldAdvanceTime: true });
+        mockFetchUpdateIds.mockReset();
+        mockFetchUpdateStatus.mockReset();
+        Object.defineProperty(document, 'visibilityState', {
+            value: 'visible',
+            configurable: true,
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    // 1. Fetches update IDs and statuses on mount
+    it('fetches update IDs and statuses on mount', async () => {
+        mockFetchUpdateIds.mockResolvedValue(['update-1', 'update-2']);
+        mockFetchUpdateStatus.mockImplementation((_baseUrl, id) =>
+            Promise.resolve(id === 'update-1' ? STATUS_PENDING : STATUS_IN_PROGRESS)
+        );
+
+        const { result } = renderHook(() => useUpdatesPolling(BASE_URL, DEFAULT_INTERVAL));
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        expect(result.current.updates).toHaveLength(2);
+        expect(result.current.updates[0]).toEqual({ id: 'update-1', status: STATUS_PENDING });
+        expect(result.current.updates[1]).toEqual({ id: 'update-2', status: STATUS_IN_PROGRESS });
+        expect(result.current.error).toBeNull();
+        expect(result.current.notAvailable).toBe(false);
+    });
+
+    // 2. Returns empty updates when no IDs
+    it('returns empty updates when no IDs', async () => {
+        mockFetchUpdateIds.mockResolvedValue([]);
+
+        const { result } = renderHook(() => useUpdatesPolling(BASE_URL, DEFAULT_INTERVAL));
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        expect(result.current.updates).toHaveLength(0);
+        expect(result.current.error).toBeNull();
+        expect(result.current.notAvailable).toBe(false);
+    });
+
+    // 3. Polls at interval
+    it('polls at interval', async () => {
+        mockFetchUpdateIds.mockResolvedValue(['update-1']);
+        mockFetchUpdateStatus.mockResolvedValue(STATUS_PENDING);
+
+        renderHook(() => useUpdatesPolling(BASE_URL, DEFAULT_INTERVAL));
+
+        await waitFor(() => {
+            expect(mockFetchUpdateIds).toHaveBeenCalledTimes(1);
+        });
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_INTERVAL);
+        });
+
+        await waitFor(() => {
+            expect(mockFetchUpdateIds).toHaveBeenCalledTimes(2);
+        });
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_INTERVAL);
+        });
+
+        await waitFor(() => {
+            expect(mockFetchUpdateIds).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    // 4. Does not fetch when baseUrl is null
+    it('does not fetch when baseUrl is null', async () => {
+        const { result } = renderHook(() => useUpdatesPolling(null, DEFAULT_INTERVAL));
+
+        // Give time for any potential spurious calls
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_INTERVAL * 2);
+        });
+
+        expect(mockFetchUpdateIds).not.toHaveBeenCalled();
+        expect(mockFetchUpdateStatus).not.toHaveBeenCalled();
+        expect(result.current.updates).toHaveLength(0);
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.error).toBeNull();
+        expect(result.current.notAvailable).toBe(false);
+    });
+
+    // 5. Sets notAvailable on 501
+    it('sets notAvailable on 501 (UpdatesApiError)', async () => {
+        mockFetchUpdateIds.mockRejectedValue(new UpdatesApiError('Not implemented', 501));
+
+        const { result } = renderHook(() => useUpdatesPolling(BASE_URL, DEFAULT_INTERVAL));
+
+        await waitFor(() => {
+            expect(result.current.notAvailable).toBe(true);
+        });
+
+        expect(result.current.updates).toHaveLength(0);
+        expect(result.current.isLoading).toBe(false);
+    });
+
+    // 6. Swallows non-501 fetch errors, recovers on next poll
+    it('swallows non-501 fetch errors, recovers on next poll', async () => {
+        mockFetchUpdateIds.mockRejectedValueOnce(new Error('Network error')).mockResolvedValue(['update-1']);
+        mockFetchUpdateStatus.mockResolvedValue(STATUS_PENDING);
+
+        const { result } = renderHook(() => useUpdatesPolling(BASE_URL, DEFAULT_INTERVAL));
+
+        // First poll fails
+        await waitFor(() => {
+            expect(result.current.error).not.toBeNull();
+        });
+        expect(result.current.notAvailable).toBe(false);
+        expect(result.current.updates).toHaveLength(0);
+
+        // Next poll succeeds - error clears and updates appear
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_INTERVAL);
+        });
+
+        await waitFor(() => {
+            expect(result.current.updates).toHaveLength(1);
+        });
+        expect(result.current.error).toBeNull();
+    });
+
+    // 7. Pauses polling when tab is hidden, resumes + fetches when visible
+    it('pauses polling when tab is hidden, resumes and fetches when visible', async () => {
+        mockFetchUpdateIds.mockResolvedValue([]);
+
+        renderHook(() => useUpdatesPolling(BASE_URL, DEFAULT_INTERVAL));
+
+        await waitFor(() => {
+            expect(mockFetchUpdateIds).toHaveBeenCalledTimes(1);
+        });
+
+        // Hide the tab
+        await act(async () => {
+            Object.defineProperty(document, 'visibilityState', {
+                value: 'hidden',
+                configurable: true,
+            });
+            document.dispatchEvent(new Event('visibilitychange'));
+        });
+
+        // Advance past several intervals - should not poll
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_INTERVAL * 3);
+        });
+
+        expect(mockFetchUpdateIds).toHaveBeenCalledTimes(1);
+
+        // Show the tab again
+        await act(async () => {
+            Object.defineProperty(document, 'visibilityState', {
+                value: 'visible',
+                configurable: true,
+            });
+            document.dispatchEvent(new Event('visibilitychange'));
+        });
+
+        // Should fetch immediately on becoming visible
+        await waitFor(() => {
+            expect(mockFetchUpdateIds).toHaveBeenCalledTimes(2);
+        });
+
+        // And resume interval polling
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_INTERVAL);
+        });
+
+        await waitFor(() => {
+            expect(mockFetchUpdateIds).toHaveBeenCalledTimes(3);
+        });
+    });
+
+    // 8. Cleans up on unmount (no additional calls after)
+    it('cleans up on unmount - no more calls after unmount', async () => {
+        mockFetchUpdateIds.mockResolvedValue([]);
+
+        const { unmount } = renderHook(() => useUpdatesPolling(BASE_URL, DEFAULT_INTERVAL));
+
+        await waitFor(() => {
+            expect(mockFetchUpdateIds).toHaveBeenCalledTimes(1);
+        });
+
+        unmount();
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_INTERVAL * 3);
+        });
+
+        // Only the initial call - no more after unmount
+        expect(mockFetchUpdateIds).toHaveBeenCalledTimes(1);
+    });
+
+    // 9. refresh() triggers immediate fetch
+    it('refresh() triggers immediate fetch', async () => {
+        mockFetchUpdateIds.mockResolvedValue(['update-1']);
+        mockFetchUpdateStatus.mockResolvedValue(STATUS_PENDING);
+
+        const { result } = renderHook(() => useUpdatesPolling(BASE_URL, DEFAULT_INTERVAL));
+
+        await waitFor(() => {
+            expect(mockFetchUpdateIds).toHaveBeenCalledTimes(1);
+        });
+
+        // Call refresh before next interval
+        await act(async () => {
+            result.current.refresh();
+        });
+
+        await waitFor(() => {
+            expect(mockFetchUpdateIds).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    // 10. Handles individual status fetch failures gracefully (null status for that entry)
+    it('handles individual status fetch failures gracefully with null status', async () => {
+        mockFetchUpdateIds.mockResolvedValue(['update-ok', 'update-fail', 'update-ok-2']);
+        mockFetchUpdateStatus.mockImplementation((_baseUrl, id) => {
+            if (id === 'update-fail') {
+                return Promise.reject(new Error('Status fetch failed'));
+            }
+            return Promise.resolve(STATUS_PENDING);
+        });
+
+        const { result } = renderHook(() => useUpdatesPolling(BASE_URL, DEFAULT_INTERVAL));
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
+
+        expect(result.current.updates).toHaveLength(3);
+
+        const okEntry = result.current.updates.find((u) => u.id === 'update-ok');
+        const failEntry = result.current.updates.find((u) => u.id === 'update-fail');
+        const ok2Entry = result.current.updates.find((u) => u.id === 'update-ok-2');
+
+        expect(okEntry?.status).toEqual(STATUS_PENDING);
+        expect(failEntry?.status).toBeNull();
+        expect(ok2Entry?.status).toEqual(STATUS_PENDING);
+    });
+
+    // isLoading: true only on initial fetch when no existing updates
+    it('shows isLoading true only on initial fetch, not on subsequent polls', async () => {
+        let resolveFirst: (ids: string[]) => void = () => {};
+        mockFetchUpdateIds.mockReturnValueOnce(
+            new Promise<string[]>((resolve) => {
+                resolveFirst = resolve;
+            })
+        );
+        mockFetchUpdateIds.mockResolvedValue(['update-1']);
+        mockFetchUpdateStatus.mockResolvedValue(STATUS_PENDING);
+
+        const { result } = renderHook(() => useUpdatesPolling(BASE_URL, DEFAULT_INTERVAL));
+
+        // Initial load: isLoading should be true
+        expect(result.current.isLoading).toBe(true);
+
+        resolveFirst(['update-1']);
+
+        await waitFor(() => {
+            expect(result.current.isLoading).toBe(false);
+        });
+        expect(result.current.updates).toHaveLength(1);
+
+        // Subsequent poll: isLoading should stay false
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(DEFAULT_INTERVAL);
+        });
+
+        // isLoading must not flip back to true during poll
+        expect(result.current.isLoading).toBe(false);
+    });
+});

--- a/src/hooks/useUpdatesPolling.test.ts
+++ b/src/hooks/useUpdatesPolling.test.ts
@@ -15,7 +15,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useUpdatesPolling } from './useUpdatesPolling';
-import type { UpdateStatus } from '@/lib/types';
+import type { UpdateEntry, UpdateStatus } from '@/lib/types';
 
 vi.mock('@/lib/updates-api', async (importOriginal) => {
     const original = await importOriginal<typeof import('@/lib/updates-api')>();
@@ -280,9 +280,9 @@ describe('useUpdatesPolling', () => {
 
         expect(result.current.updates).toHaveLength(3);
 
-        const okEntry = result.current.updates.find((u) => u.id === 'update-ok');
-        const failEntry = result.current.updates.find((u) => u.id === 'update-fail');
-        const ok2Entry = result.current.updates.find((u) => u.id === 'update-ok-2');
+        const okEntry = result.current.updates.find((u: UpdateEntry) => u.id === 'update-ok');
+        const failEntry = result.current.updates.find((u: UpdateEntry) => u.id === 'update-fail');
+        const ok2Entry = result.current.updates.find((u: UpdateEntry) => u.id === 'update-ok-2');
 
         expect(okEntry?.status).toEqual(STATUS_PENDING);
         expect(failEntry?.status).toBeNull();

--- a/src/hooks/useUpdatesPolling.ts
+++ b/src/hooks/useUpdatesPolling.ts
@@ -22,14 +22,13 @@ export interface UseUpdatesPollingResult {
     error: string | null;
     notAvailable: boolean;
     refresh: () => void;
+    effectiveInterval: number;
 }
 
-const DEFAULT_INTERVAL_MS = 2000;
+const IDLE_INTERVAL_MS = 5000;
+const ACTIVE_INTERVAL_MS = 2000;
 
-export function useUpdatesPolling(
-    baseUrl: string | null,
-    intervalMs: number = DEFAULT_INTERVAL_MS
-): UseUpdatesPollingResult {
+export function useUpdatesPolling(baseUrl: string | null, intervalMs?: number): UseUpdatesPollingResult {
     const [updates, setUpdates] = useState<UpdateEntry[]>([]);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -121,16 +120,20 @@ export function useUpdatesPolling(
         };
     }, [baseUrl, isVisible, refreshTick, doFetch]);
 
+    // Adaptive polling: 2s when any update is active, 5s otherwise
+    const hasActiveUpdate = updates.some((u) => u.status?.status === 'inProgress' || u.status?.status === 'pending');
+    const effectiveInterval = intervalMs ?? (hasActiveUpdate ? ACTIVE_INTERVAL_MS : IDLE_INTERVAL_MS);
+
     // Interval polling (only when visible and baseUrl is set)
     useEffect(() => {
         if (!baseUrl || !isVisible) return;
 
         const id = setInterval(() => {
             void doFetch(false);
-        }, intervalMs);
+        }, effectiveInterval);
 
         return () => clearInterval(id);
-    }, [baseUrl, isVisible, intervalMs, doFetch]);
+    }, [baseUrl, isVisible, effectiveInterval, doFetch]);
 
     // Reset state when baseUrl changes to null
     useEffect(() => {
@@ -148,5 +151,5 @@ export function useUpdatesPolling(
         setRefreshTick((t) => t + 1);
     }, []);
 
-    return { updates, isLoading, error, notAvailable, refresh };
+    return { updates, isLoading, error, notAvailable, refresh, effectiveInterval };
 }

--- a/src/hooks/useUpdatesPolling.ts
+++ b/src/hooks/useUpdatesPolling.ts
@@ -82,9 +82,11 @@ export function useUpdatesPolling(baseUrl: string | null, intervalMs?: number): 
                 if ((err as { name?: string }).name === 'AbortError') return;
 
                 if (err instanceof UpdatesApiError && err.status === 501) {
+                    setError(null);
                     setNotAvailable(true);
                     setUpdates([]);
                 } else {
+                    setNotAvailable(false);
                     setError(err instanceof Error ? err.message : String(err));
                 }
             } finally {

--- a/src/hooks/useUpdatesPolling.ts
+++ b/src/hooks/useUpdatesPolling.ts
@@ -41,15 +41,20 @@ export function useUpdatesPolling(baseUrl: string | null, intervalMs?: number): 
     const hasLoadedRef = useRef(false);
     // AbortController for in-flight fetches
     const abortRef = useRef<AbortController | null>(null);
+    const fetchingRef = useRef(false);
     const [refreshTick, setRefreshTick] = useState(0);
 
     const doFetch = useCallback(
-        async (isInitial: boolean) => {
+        async (isInitial: boolean, force: boolean = false) => {
             if (!baseUrl) return;
+
+            // Skip if a fetch is already in flight (prevents starvation on slow networks)
+            if (fetchingRef.current && !force) return;
 
             abortRef.current?.abort();
             const controller = new AbortController();
             abortRef.current = controller;
+            fetchingRef.current = true;
 
             if (isInitial && !hasLoadedRef.current) {
                 setIsLoading(true);
@@ -90,6 +95,7 @@ export function useUpdatesPolling(baseUrl: string | null, intervalMs?: number): 
                     setError(err instanceof Error ? err.message : String(err));
                 }
             } finally {
+                fetchingRef.current = false;
                 if (!controller.signal.aborted) {
                     setIsLoading(false);
                 }
@@ -113,7 +119,7 @@ export function useUpdatesPolling(baseUrl: string | null, intervalMs?: number): 
         if (!isVisible) return;
 
         const isInitial = !hasLoadedRef.current;
-        void doFetch(isInitial);
+        void doFetch(isInitial, true);
 
         return () => {
             abortRef.current?.abort();

--- a/src/hooks/useUpdatesPolling.ts
+++ b/src/hooks/useUpdatesPolling.ts
@@ -1,0 +1,152 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchUpdateIds, fetchUpdateStatus, UpdatesApiError } from '@/lib/updates-api';
+import type { UpdateEntry } from '@/lib/types';
+
+export interface UseUpdatesPollingResult {
+    updates: UpdateEntry[];
+    isLoading: boolean;
+    error: string | null;
+    notAvailable: boolean;
+    refresh: () => void;
+}
+
+const DEFAULT_INTERVAL_MS = 2000;
+
+export function useUpdatesPolling(
+    baseUrl: string | null,
+    intervalMs: number = DEFAULT_INTERVAL_MS
+): UseUpdatesPollingResult {
+    const [updates, setUpdates] = useState<UpdateEntry[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [notAvailable, setNotAvailable] = useState(false);
+    const [isVisible, setIsVisible] = useState(
+        typeof document === 'undefined' ? true : document.visibilityState === 'visible'
+    );
+
+    // Tracks whether we have ever successfully loaded data (for isLoading semantics)
+    const hasLoadedRef = useRef(false);
+    // AbortController for in-flight fetches
+    const abortRef = useRef<AbortController | null>(null);
+    // Ref to trigger immediate refresh
+    const refreshCountRef = useRef(0);
+    const [refreshTick, setRefreshTick] = useState(0);
+
+    const doFetch = useCallback(
+        async (isInitial: boolean) => {
+            if (!baseUrl) return;
+
+            abortRef.current?.abort();
+            const controller = new AbortController();
+            abortRef.current = controller;
+
+            if (isInitial && !hasLoadedRef.current) {
+                setIsLoading(true);
+            }
+
+            try {
+                const ids = await fetchUpdateIds(baseUrl, controller.signal);
+
+                if (controller.signal.aborted) return;
+
+                // Fetch status for each ID individually; failures yield null status
+                const entries: UpdateEntry[] = await Promise.all(
+                    ids.map(async (id) => {
+                        try {
+                            const status = await fetchUpdateStatus(baseUrl, id, controller.signal);
+                            return { id, status };
+                        } catch {
+                            return { id, status: null };
+                        }
+                    })
+                );
+
+                if (controller.signal.aborted) return;
+
+                setUpdates(entries);
+                setError(null);
+                setNotAvailable(false);
+                hasLoadedRef.current = true;
+            } catch (err) {
+                if ((err as { name?: string }).name === 'AbortError') return;
+
+                if (err instanceof UpdatesApiError && err.status === 501) {
+                    setNotAvailable(true);
+                    setUpdates([]);
+                } else {
+                    setError(err instanceof Error ? err.message : String(err));
+                }
+            } finally {
+                if (!controller.signal.aborted) {
+                    setIsLoading(false);
+                }
+            }
+        },
+        [baseUrl]
+    );
+
+    // Listen for visibility changes
+    useEffect(() => {
+        const onVisibilityChange = () => {
+            setIsVisible(document.visibilityState === 'visible');
+        };
+        document.addEventListener('visibilitychange', onVisibilityChange);
+        return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+    }, []);
+
+    // Fetch on becoming visible (after being hidden), on refreshTick, and on baseUrl change
+    useEffect(() => {
+        if (!baseUrl) return;
+        if (!isVisible) return;
+
+        const isInitial = !hasLoadedRef.current;
+        void doFetch(isInitial);
+
+        return () => {
+            abortRef.current?.abort();
+        };
+    }, [baseUrl, isVisible, refreshTick, doFetch]);
+
+    // Interval polling (only when visible and baseUrl is set)
+    useEffect(() => {
+        if (!baseUrl || !isVisible) return;
+
+        const id = setInterval(() => {
+            void doFetch(false);
+        }, intervalMs);
+
+        return () => clearInterval(id);
+    }, [baseUrl, isVisible, intervalMs, doFetch]);
+
+    // Reset state when baseUrl changes to null
+    useEffect(() => {
+        if (!baseUrl) {
+            hasLoadedRef.current = false;
+            setUpdates([]);
+            setError(null);
+            setNotAvailable(false);
+            setIsLoading(false);
+        }
+    }, [baseUrl]);
+
+    const refresh = useCallback(() => {
+        refreshCountRef.current += 1;
+        setRefreshTick((t) => t + 1);
+    }, []);
+
+    return { updates, isLoading, error, notAvailable, refresh };
+}

--- a/src/hooks/useUpdatesPolling.ts
+++ b/src/hooks/useUpdatesPolling.ts
@@ -41,8 +41,6 @@ export function useUpdatesPolling(baseUrl: string | null, intervalMs?: number): 
     const hasLoadedRef = useRef(false);
     // AbortController for in-flight fetches
     const abortRef = useRef<AbortController | null>(null);
-    // Ref to trigger immediate refresh
-    const refreshCountRef = useRef(0);
     const [refreshTick, setRefreshTick] = useState(0);
 
     const doFetch = useCallback(
@@ -147,7 +145,6 @@ export function useUpdatesPolling(baseUrl: string | null, intervalMs?: number): 
     }, [baseUrl]);
 
     const refresh = useCallback(() => {
-        refreshCountRef.current += 1;
         setRefreshTick((t) => t + 1);
     }, []);
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -967,5 +967,5 @@ export interface UpdateStatus {
  */
 export interface UpdateEntry {
     id: string;
-    status: UpdateStatus | null; // null while status is loading
+    status: UpdateStatus | null; // null = status fetch failed
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -933,3 +933,39 @@ export interface TokenRevokeRequest {
     /** Token type hint */
     token_type_hint?: 'refresh_token' | 'access_token';
 }
+
+// =============================================================================
+// Section 10: Software Updates (SOVD spec)
+// =============================================================================
+
+/**
+ * Update status values from SOVD spec
+ */
+export type UpdateStatusValue = 'pending' | 'inProgress' | 'completed' | 'failed';
+
+/**
+ * Sub-step progress for an update operation
+ */
+export interface UpdateSubProgress {
+    name: string;
+    progress: number; // 0-100
+}
+
+/**
+ * Status response from GET /updates/{id}/status
+ */
+export interface UpdateStatus {
+    status: UpdateStatusValue;
+    progress?: number; // 0-100
+    sub_progress?: UpdateSubProgress[];
+    error?: string;
+}
+
+/**
+ * Combined view: update ID + its polled status
+ * Assembled by useUpdatesPolling hook
+ */
+export interface UpdateEntry {
+    id: string;
+    status: UpdateStatus | null; // null while status is loading
+}

--- a/src/lib/updates-api.test.ts
+++ b/src/lib/updates-api.test.ts
@@ -1,0 +1,147 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+    fetchUpdateIds,
+    fetchUpdateStatus,
+    fetchUpdateDetail,
+    triggerPrepare,
+    triggerExecute,
+    triggerAutomated,
+    deleteUpdate,
+    UpdatesApiError,
+} from './updates-api';
+
+const BASE = 'http://localhost:8080/api/v1';
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('fetchUpdateIds', () => {
+    it('returns array of IDs on success', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({ items: ['fw-v2', 'fw-v3'] }), { status: 200 })
+        );
+        const ids = await fetchUpdateIds(BASE);
+        expect(ids).toEqual(['fw-v2', 'fw-v3']);
+        expect(fetch).toHaveBeenCalledWith(`${BASE}/updates`, { signal: undefined });
+    });
+
+    it('returns empty array when no updates', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] }), { status: 200 }));
+        const ids = await fetchUpdateIds(BASE);
+        expect(ids).toEqual([]);
+    });
+
+    it('throws UpdatesApiError with status 501 when backend not configured', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({ error_code: 'not_implemented', message: 'not configured' }), { status: 501 })
+        );
+        await expect(fetchUpdateIds(BASE)).rejects.toThrow(UpdatesApiError);
+        await expect(fetchUpdateIds(BASE)).rejects.toMatchObject({ status: 501 });
+    });
+
+    it('passes AbortSignal to fetch', async () => {
+        const controller = new AbortController();
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ items: [] }), { status: 200 }));
+        await fetchUpdateIds(BASE, controller.signal);
+        expect(fetch).toHaveBeenCalledWith(`${BASE}/updates`, { signal: controller.signal });
+    });
+});
+
+describe('fetchUpdateStatus', () => {
+    it('returns status object on success', async () => {
+        const status = { status: 'inProgress', progress: 45 };
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify(status), { status: 200 }));
+        const result = await fetchUpdateStatus(BASE, 'fw-v2');
+        expect(result).toEqual(status);
+        expect(fetch).toHaveBeenCalledWith(`${BASE}/updates/fw-v2/status`, { signal: undefined });
+    });
+
+    it('throws on 404 (update not found)', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({ message: 'not found' }), { status: 404 })
+        );
+        await expect(fetchUpdateStatus(BASE, 'missing')).rejects.toThrow(UpdatesApiError);
+    });
+});
+
+describe('fetchUpdateDetail', () => {
+    it('returns arbitrary JSON detail object', async () => {
+        const detail = { id: 'fw-v2', custom_field: 'value', nested: { a: 1 } };
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify(detail), { status: 200 }));
+        const result = await fetchUpdateDetail(BASE, 'fw-v2');
+        expect(result).toEqual(detail);
+    });
+});
+
+describe('triggerPrepare', () => {
+    it('sends PUT and resolves on 202', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }));
+        await expect(triggerPrepare(BASE, 'fw-v2')).resolves.toBeUndefined();
+        expect(fetch).toHaveBeenCalledWith(`${BASE}/updates/fw-v2/prepare`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}',
+        });
+    });
+
+    it('throws on 409 (already in progress)', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({ message: 'in progress' }), { status: 409 })
+        );
+        await expect(triggerPrepare(BASE, 'fw-v2')).rejects.toMatchObject({ status: 409 });
+    });
+});
+
+describe('triggerExecute', () => {
+    it('sends PUT and resolves on 202', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }));
+        await expect(triggerExecute(BASE, 'fw-v2')).resolves.toBeUndefined();
+        expect(fetch).toHaveBeenCalledWith(`${BASE}/updates/fw-v2/execute`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}',
+        });
+    });
+});
+
+describe('triggerAutomated', () => {
+    it('sends PUT and resolves on 202', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }));
+        await expect(triggerAutomated(BASE, 'fw-v2')).resolves.toBeUndefined();
+        expect(fetch).toHaveBeenCalledWith(`${BASE}/updates/fw-v2/automated`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}',
+        });
+    });
+});
+
+describe('deleteUpdate', () => {
+    it('sends DELETE and resolves on 204', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 204 }));
+        await expect(deleteUpdate(BASE, 'fw-v2')).resolves.toBeUndefined();
+        expect(fetch).toHaveBeenCalledWith(`${BASE}/updates/fw-v2`, { method: 'DELETE' });
+    });
+
+    it('throws on 409 (in progress)', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({ message: 'in progress' }), { status: 409 })
+        );
+        await expect(deleteUpdate(BASE, 'fw-v2')).rejects.toMatchObject({ status: 409 });
+    });
+});

--- a/src/lib/updates-api.ts
+++ b/src/lib/updates-api.ts
@@ -69,31 +69,31 @@ export async function fetchUpdateDetail(
 }
 
 /** PUT /updates/{id}/prepare - start preparation (202) */
-export async function triggerPrepare(baseUrl: string, id: string): Promise<void> {
+export async function triggerPrepare(baseUrl: string, id: string, data?: unknown): Promise<void> {
     const res = await fetch(`${baseUrl}/updates/${id}/prepare`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: '{}',
+        body: JSON.stringify(data ?? {}),
     });
     await ensureOk(res);
 }
 
 /** PUT /updates/{id}/execute - start execution (202) */
-export async function triggerExecute(baseUrl: string, id: string): Promise<void> {
+export async function triggerExecute(baseUrl: string, id: string, data?: unknown): Promise<void> {
     const res = await fetch(`${baseUrl}/updates/${id}/execute`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: '{}',
+        body: JSON.stringify(data ?? {}),
     });
     await ensureOk(res);
 }
 
 /** PUT /updates/{id}/automated - start automated update (202) */
-export async function triggerAutomated(baseUrl: string, id: string): Promise<void> {
+export async function triggerAutomated(baseUrl: string, id: string, data?: unknown): Promise<void> {
     const res = await fetch(`${baseUrl}/updates/${id}/automated`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: '{}',
+        body: JSON.stringify(data ?? {}),
     });
     await ensureOk(res);
 }

--- a/src/lib/updates-api.ts
+++ b/src/lib/updates-api.ts
@@ -1,0 +1,105 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { UpdateStatus } from './types';
+
+/**
+ * Error thrown by updates API helpers.
+ * Carries the HTTP status code for callers to distinguish
+ * 501 (no backend) from other errors.
+ */
+export class UpdatesApiError extends Error {
+    constructor(
+        message: string,
+        public readonly status: number
+    ) {
+        super(message);
+        this.name = 'UpdatesApiError';
+    }
+}
+
+async function ensureOk(res: Response): Promise<void> {
+    if (!res.ok) {
+        let message = `HTTP ${res.status}`;
+        try {
+            const body = await res.json();
+            if (body.message) message = body.message;
+        } catch {
+            // ignore parse errors
+        }
+        throw new UpdatesApiError(message, res.status);
+    }
+}
+
+/** GET /updates - returns list of update IDs */
+export async function fetchUpdateIds(baseUrl: string, signal?: AbortSignal): Promise<string[]> {
+    const res = await fetch(`${baseUrl}/updates`, { signal });
+    await ensureOk(res);
+    const data: { items: string[] } = await res.json();
+    return data.items;
+}
+
+/** GET /updates/{id}/status - returns update status with progress */
+export async function fetchUpdateStatus(baseUrl: string, id: string, signal?: AbortSignal): Promise<UpdateStatus> {
+    const res = await fetch(`${baseUrl}/updates/${id}/status`, { signal });
+    await ensureOk(res);
+    return res.json();
+}
+
+/** GET /updates/{id} - returns plugin-defined detail object */
+export async function fetchUpdateDetail(
+    baseUrl: string,
+    id: string,
+    signal?: AbortSignal
+): Promise<Record<string, unknown>> {
+    const res = await fetch(`${baseUrl}/updates/${id}`, { signal });
+    await ensureOk(res);
+    return res.json();
+}
+
+/** PUT /updates/{id}/prepare - start preparation (202) */
+export async function triggerPrepare(baseUrl: string, id: string): Promise<void> {
+    const res = await fetch(`${baseUrl}/updates/${id}/prepare`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+    });
+    await ensureOk(res);
+}
+
+/** PUT /updates/{id}/execute - start execution (202) */
+export async function triggerExecute(baseUrl: string, id: string): Promise<void> {
+    const res = await fetch(`${baseUrl}/updates/${id}/execute`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+    });
+    await ensureOk(res);
+}
+
+/** PUT /updates/{id}/automated - start automated update (202) */
+export async function triggerAutomated(baseUrl: string, id: string): Promise<void> {
+    const res = await fetch(`${baseUrl}/updates/${id}/automated`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+    });
+    await ensureOk(res);
+}
+
+/** DELETE /updates/{id} - remove update (204) */
+export async function deleteUpdate(baseUrl: string, id: string): Promise<void> {
+    const res = await fetch(`${baseUrl}/updates/${id}`, { method: 'DELETE' });
+    await ensureOk(res);
+}

--- a/src/lib/updates-api.ts
+++ b/src/lib/updates-api.ts
@@ -20,12 +20,12 @@ import type { UpdateStatus } from './types';
  * 501 (no backend) from other errors.
  */
 export class UpdatesApiError extends Error {
-    constructor(
-        message: string,
-        public readonly status: number
-    ) {
+    readonly status: number;
+
+    constructor(message: string, status: number) {
         super(message);
         this.name = 'UpdatesApiError';
+        this.status = status;
     }
 }
 

--- a/src/lib/updates-api.ts
+++ b/src/lib/updates-api.ts
@@ -42,6 +42,11 @@ async function ensureOk(res: Response): Promise<void> {
     }
 }
 
+function updatePath(baseUrl: string, id: string, suffix?: string): string {
+    const encoded = encodeURIComponent(id);
+    return suffix ? `${baseUrl}/updates/${encoded}/${suffix}` : `${baseUrl}/updates/${encoded}`;
+}
+
 /** GET /updates - returns list of update IDs */
 export async function fetchUpdateIds(baseUrl: string, signal?: AbortSignal): Promise<string[]> {
     const res = await fetch(`${baseUrl}/updates`, { signal });
@@ -52,7 +57,7 @@ export async function fetchUpdateIds(baseUrl: string, signal?: AbortSignal): Pro
 
 /** GET /updates/{id}/status - returns update status with progress */
 export async function fetchUpdateStatus(baseUrl: string, id: string, signal?: AbortSignal): Promise<UpdateStatus> {
-    const res = await fetch(`${baseUrl}/updates/${id}/status`, { signal });
+    const res = await fetch(updatePath(baseUrl, id, 'status'), { signal });
     await ensureOk(res);
     return res.json();
 }
@@ -63,14 +68,14 @@ export async function fetchUpdateDetail(
     id: string,
     signal?: AbortSignal
 ): Promise<Record<string, unknown>> {
-    const res = await fetch(`${baseUrl}/updates/${id}`, { signal });
+    const res = await fetch(updatePath(baseUrl, id), { signal });
     await ensureOk(res);
     return res.json();
 }
 
 /** PUT /updates/{id}/prepare - start preparation (202) */
 export async function triggerPrepare(baseUrl: string, id: string, data?: unknown): Promise<void> {
-    const res = await fetch(`${baseUrl}/updates/${id}/prepare`, {
+    const res = await fetch(updatePath(baseUrl, id, 'prepare'), {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data ?? {}),
@@ -80,7 +85,7 @@ export async function triggerPrepare(baseUrl: string, id: string, data?: unknown
 
 /** PUT /updates/{id}/execute - start execution (202) */
 export async function triggerExecute(baseUrl: string, id: string, data?: unknown): Promise<void> {
-    const res = await fetch(`${baseUrl}/updates/${id}/execute`, {
+    const res = await fetch(updatePath(baseUrl, id, 'execute'), {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data ?? {}),
@@ -90,7 +95,7 @@ export async function triggerExecute(baseUrl: string, id: string, data?: unknown
 
 /** PUT /updates/{id}/automated - start automated update (202) */
 export async function triggerAutomated(baseUrl: string, id: string, data?: unknown): Promise<void> {
-    const res = await fetch(`${baseUrl}/updates/${id}/automated`, {
+    const res = await fetch(updatePath(baseUrl, id, 'automated'), {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data ?? {}),
@@ -100,6 +105,6 @@ export async function triggerAutomated(baseUrl: string, id: string, data?: unkno
 
 /** DELETE /updates/{id} - remove update (204) */
 export async function deleteUpdate(baseUrl: string, id: string): Promise<void> {
-    const res = await fetch(`${baseUrl}/updates/${id}`, { method: 'DELETE' });
+    const res = await fetch(updatePath(baseUrl, id), { method: 'DELETE' });
     await ensureOk(res);
 }

--- a/src/lib/updates-api.ts
+++ b/src/lib/updates-api.ts
@@ -51,15 +51,19 @@ function updatePath(baseUrl: string, id: string, suffix?: string): string {
 export async function fetchUpdateIds(baseUrl: string, signal?: AbortSignal): Promise<string[]> {
     const res = await fetch(`${baseUrl}/updates`, { signal });
     await ensureOk(res);
-    const data: { items: string[] } = await res.json();
-    return data.items;
+    const data = await res.json();
+    return Array.isArray(data?.items) ? data.items : [];
 }
 
 /** GET /updates/{id}/status - returns update status with progress */
 export async function fetchUpdateStatus(baseUrl: string, id: string, signal?: AbortSignal): Promise<UpdateStatus> {
     const res = await fetch(updatePath(baseUrl, id, 'status'), { signal });
     await ensureOk(res);
-    return res.json();
+    const data = await res.json();
+    if (typeof data?.status !== 'string') {
+        throw new UpdatesApiError('Invalid status response', 0);
+    }
+    return data as UpdateStatus;
 }
 
 /** GET /updates/{id} - returns plugin-defined detail object */
@@ -74,37 +78,45 @@ export async function fetchUpdateDetail(
 }
 
 /** PUT /updates/{id}/prepare - start preparation (202) */
-export async function triggerPrepare(baseUrl: string, id: string, data?: unknown): Promise<void> {
+export async function triggerPrepare(baseUrl: string, id: string, data?: unknown, signal?: AbortSignal): Promise<void> {
     const res = await fetch(updatePath(baseUrl, id, 'prepare'), {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data ?? {}),
+        signal,
     });
     await ensureOk(res);
 }
 
 /** PUT /updates/{id}/execute - start execution (202) */
-export async function triggerExecute(baseUrl: string, id: string, data?: unknown): Promise<void> {
+export async function triggerExecute(baseUrl: string, id: string, data?: unknown, signal?: AbortSignal): Promise<void> {
     const res = await fetch(updatePath(baseUrl, id, 'execute'), {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data ?? {}),
+        signal,
     });
     await ensureOk(res);
 }
 
 /** PUT /updates/{id}/automated - start automated update (202) */
-export async function triggerAutomated(baseUrl: string, id: string, data?: unknown): Promise<void> {
+export async function triggerAutomated(
+    baseUrl: string,
+    id: string,
+    data?: unknown,
+    signal?: AbortSignal
+): Promise<void> {
     const res = await fetch(updatePath(baseUrl, id, 'automated'), {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data ?? {}),
+        signal,
     });
     await ensureOk(res);
 }
 
 /** DELETE /updates/{id} - remove update (204) */
-export async function deleteUpdate(baseUrl: string, id: string): Promise<void> {
-    const res = await fetch(updatePath(baseUrl, id), { method: 'DELETE' });
+export async function deleteUpdate(baseUrl: string, id: string, signal?: AbortSignal): Promise<void> {
+    const res = await fetch(updatePath(baseUrl, id), { method: 'DELETE', signal });
     await ensureOk(res);
 }


### PR DESCRIPTION
# Pull Request

## Summary

Add a Software Updates Dashboard view for monitoring OTA update lifecycle. Server-level dashboard (same pattern as Faults Dashboard) that polls `/api/v1/updates/*` endpoints and displays update status with progress tracking.

New components:
- **UpdateCard** - single update card with status badge, progress bar, sub-progress list, action buttons, and View Details dialog
- **UpdatesDashboard** - grid of UpdateCards with summary counts, empty/error/501 states, and adaptive polling (5s idle, 2s when active)
- **useUpdatesPolling** hook - self-contained polling with visibility pause, AbortController cleanup, and error recovery
- **updates-api.ts** - raw fetch helpers for all 7 update endpoints (generated client has broken type resolution, tracked in selfpatch/ros2_medkit_clients#19)

Navigation: new "Software Updates" button in sidebar Quick Actions, new `updates-dashboard` ViewMode.

---

## Issue

- closes #47

---

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- 42 new tests across 4 test files (updates-api, useUpdatesPolling, UpdateCard, UpdatesDashboard)
- 332 total tests passing, no regressions
- `npm run lint` and `npm run typecheck` clean
- Manual verification: sidebar button visible, dashboard renders all states

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Docs were updated if behavior or public API changed