### PR TITLE
fix: resolve empty resource tabs and missing peer component children

### DIFF
--- a/src/components/EntityResourceTabs.test.tsx
+++ b/src/components/EntityResourceTabs.test.tsx
@@ -69,7 +69,7 @@ describe('EntityResourceTabs', () => {
         render(<EntityResourceTabs entityId="ecu-primary" entityType="components" />);
 
         await waitFor(() => {
-            expect(mockFetchEntityData).toHaveBeenCalledWith('components', 'ecu-primary');
+            expect(mockFetchEntityData).toHaveBeenCalledWith('components', 'ecu-primary', expect.anything());
         });
 
         await waitFor(() => {
@@ -104,7 +104,7 @@ describe('EntityResourceTabs', () => {
         rerender(<EntityResourceTabs entityId="ecu-mcu" entityType="components" />);
 
         await waitFor(() => {
-            expect(mockFetchEntityData).toHaveBeenCalledWith('components', 'ecu-mcu');
+            expect(mockFetchEntityData).toHaveBeenCalledWith('components', 'ecu-mcu', expect.anything());
         });
 
         await waitFor(() => {
@@ -113,5 +113,45 @@ describe('EntityResourceTabs', () => {
 
         // Old data should be gone
         expect(screen.queryByText('/engine/temperature')).not.toBeInTheDocument();
+    });
+
+    it('does not apply stale fetch result when entity changes mid-flight', async () => {
+        // First fetch returns a promise we control, so we can switch entities
+        // while it is still in-flight and verify the old result is discarded.
+        let resolveFirst: (value: ComponentTopic[]) => void = () => {};
+        const firstPromise = new Promise<ComponentTopic[]>((resolve) => {
+            resolveFirst = resolve;
+        });
+        mockFetchEntityData.mockReturnValueOnce(firstPromise);
+
+        const { rerender } = render(<EntityResourceTabs entityId="ecu-primary" entityType="components" />);
+
+        // Switch entity while the first fetch is still pending
+        const secondTopics: ComponentTopic[] = [
+            {
+                topic: '/brake/pressure',
+                timestamp: Date.now(),
+                data: null,
+                status: 'metadata_only',
+                type: 'sensor_msgs/msg/FluidPressure',
+            },
+        ];
+        mockFetchEntityData.mockResolvedValueOnce(secondTopics);
+        rerender(<EntityResourceTabs entityId="ecu-mcu" entityType="components" />);
+
+        // New entity's fetch resolves and renders
+        await waitFor(() => {
+            expect(screen.getByText('/brake/pressure')).toBeInTheDocument();
+        });
+
+        // Late-resolve the first (aborted) fetch - it must NOT overwrite the
+        // current entity's data.
+        resolveFirst(sampleTopics());
+        // Give the microtask queue a chance to run the (hopefully discarded) setData.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(screen.queryByText('/engine/temperature')).not.toBeInTheDocument();
+        expect(screen.getByText('/brake/pressure')).toBeInTheDocument();
     });
 });

--- a/src/components/EntityResourceTabs.test.tsx
+++ b/src/components/EntityResourceTabs.test.tsx
@@ -1,0 +1,117 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { EntityResourceTabs } from './EntityResourceTabs';
+import type { ComponentTopic, Operation, Fault } from '@/lib/types';
+
+// ---- store mock ----
+
+const mockFetchEntityData = vi.fn();
+const mockFetchEntityOperations = vi.fn();
+const mockFetchConfigurations = vi.fn();
+const mockListEntityFaults = vi.fn();
+const mockSelectEntity = vi.fn();
+
+vi.mock('@/lib/store', () => ({
+    useAppStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
+        selector({
+            selectEntity: mockSelectEntity,
+            fetchEntityData: mockFetchEntityData,
+            fetchEntityOperations: mockFetchEntityOperations,
+            fetchConfigurations: mockFetchConfigurations,
+            listEntityFaults: mockListEntityFaults,
+            configurations: new Map(),
+        })
+    ),
+}));
+
+// ---- helpers ----
+
+function sampleTopics(): ComponentTopic[] {
+    return [
+        {
+            topic: '/engine/temperature',
+            timestamp: Date.now(),
+            data: null,
+            status: 'metadata_only',
+            type: 'sensor_msgs/msg/Temperature',
+        },
+    ];
+}
+
+// ---- tests ----
+
+describe('EntityResourceTabs', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockFetchEntityData.mockResolvedValue([] as ComponentTopic[]);
+        mockFetchEntityOperations.mockResolvedValue([] as Operation[]);
+        mockFetchConfigurations.mockResolvedValue(undefined);
+        mockListEntityFaults.mockResolvedValue({ items: [] as Fault[], count: 0 });
+    });
+
+    it('fetches and displays data items on first render', async () => {
+        mockFetchEntityData.mockResolvedValue(sampleTopics());
+
+        render(<EntityResourceTabs entityId="ecu-primary" entityType="components" />);
+
+        await waitFor(() => {
+            expect(mockFetchEntityData).toHaveBeenCalledWith('components', 'ecu-primary');
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('/engine/temperature')).toBeInTheDocument();
+        });
+    });
+
+    it('re-fetches data when entityId changes (loadedTabs ref race)', async () => {
+        mockFetchEntityData.mockResolvedValue(sampleTopics());
+
+        const { rerender } = render(<EntityResourceTabs entityId="ecu-primary" entityType="components" />);
+
+        // Wait for first fetch to complete
+        await waitFor(() => {
+            expect(screen.getByText('/engine/temperature')).toBeInTheDocument();
+        });
+
+        // Switch to a different entity - this is the scenario that was broken:
+        // the ref still had { data: true } from the first entity, so the load
+        // effect returned early and data stayed empty.
+        const secondTopics: ComponentTopic[] = [
+            {
+                topic: '/brake/pressure',
+                timestamp: Date.now(),
+                data: null,
+                status: 'metadata_only',
+                type: 'sensor_msgs/msg/FluidPressure',
+            },
+        ];
+        mockFetchEntityData.mockResolvedValue(secondTopics);
+
+        rerender(<EntityResourceTabs entityId="ecu-mcu" entityType="components" />);
+
+        await waitFor(() => {
+            expect(mockFetchEntityData).toHaveBeenCalledWith('components', 'ecu-mcu');
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText('/brake/pressure')).toBeInTheDocument();
+        });
+
+        // Old data should be gone
+        expect(screen.queryByText('/engine/temperature')).not.toBeInTheDocument();
+    });
+});

--- a/src/components/EntityResourceTabs.tsx
+++ b/src/components/EntityResourceTabs.tsx
@@ -65,34 +65,47 @@ export function EntityResourceTabs({ entityId, entityType, basePath, onNavigate 
         }))
     );
 
+    // AbortController for in-flight fetches. Aborted (and replaced) whenever
+    // the entity changes so stale responses never overwrite fresh ones.
+    const abortRef = useRef<AbortController | null>(null);
+
     // Lazy load resources for the active tab
     const loadTabResources = useCallback(
         async (tab: ResourceTabId) => {
             if (loadedTabsRef.current[tab]) return;
 
+            const signal = abortRef.current?.signal;
             setIsLoading(true);
             try {
                 switch (tab) {
                     case 'data': {
-                        const dataRes = await fetchEntityData(entityType, entityId).catch(() => [] as ComponentTopic[]);
+                        const dataRes = await fetchEntityData(entityType, entityId, signal).catch(
+                            () => [] as ComponentTopic[]
+                        );
+                        if (signal?.aborted) return;
                         setData(dataRes);
                         break;
                     }
                     case 'operations': {
-                        const opsRes = await fetchEntityOperations(entityType, entityId).catch(() => [] as Operation[]);
+                        const opsRes = await fetchEntityOperations(entityType, entityId, signal).catch(
+                            () => [] as Operation[]
+                        );
+                        if (signal?.aborted) return;
                         setOperations(opsRes);
                         break;
                     }
                     case 'configurations': {
-                        await fetchConfigurations(entityId, entityType);
+                        await fetchConfigurations(entityId, entityType, signal);
+                        if (signal?.aborted) return;
                         // Configurations are stored in the store's configurations map
                         break;
                     }
                     case 'faults': {
-                        const faultsRes = await listEntityFaults(entityType, entityId).catch(() => ({
+                        const faultsRes = await listEntityFaults(entityType, entityId, signal).catch(() => ({
                             items: [] as Fault[],
                             count: 0,
                         }));
+                        if (signal?.aborted) return;
                         setFaults(faultsRes.items || []);
                         break;
                     }
@@ -101,11 +114,13 @@ export function EntityResourceTabs({ entityId, entityType, basePath, onNavigate 
                         break;
                     }
                 }
+                if (signal?.aborted) return;
                 setLoadedTabs((prev) => ({ ...prev, [tab]: true }));
             } catch (error) {
+                if (signal?.aborted) return;
                 console.error(`Failed to load ${tab} resources:`, error);
             } finally {
-                setIsLoading(false);
+                if (!signal?.aborted) setIsLoading(false);
             }
         },
 
@@ -115,6 +130,11 @@ export function EntityResourceTabs({ entityId, entityType, basePath, onNavigate 
     // Reset tab state when the entity changes so stale data from the
     // previous entity does not leak into the new one.
     useEffect(() => {
+        // Abort any fetches still running for the previous entity. The
+        // next load effect will spin up a fresh controller.
+        abortRef.current?.abort();
+        abortRef.current = new AbortController();
+
         const reset: LoadedResources = {
             data: false,
             operations: false,
@@ -132,6 +152,11 @@ export function EntityResourceTabs({ entityId, entityType, basePath, onNavigate 
         setOperations([]);
         setFaults([]);
     }, [entityId, entityType]);
+
+    // Abort in-flight fetches on unmount.
+    useEffect(() => {
+        return () => abortRef.current?.abort();
+    }, []);
 
     // Load resources when tab changes
     useEffect(() => {

--- a/src/components/EntityResourceTabs.tsx
+++ b/src/components/EntityResourceTabs.tsx
@@ -115,8 +115,19 @@ export function EntityResourceTabs({ entityId, entityType, basePath, onNavigate 
     // Reset tab state when the entity changes so stale data from the
     // previous entity does not leak into the new one.
     useEffect(() => {
+        const reset: LoadedResources = {
+            data: false,
+            operations: false,
+            configurations: false,
+            faults: false,
+            logs: false,
+        };
         setActiveTab('data');
-        setLoadedTabs({ data: false, operations: false, configurations: false, faults: false, logs: false });
+        setLoadedTabs(reset);
+        // Synchronously update the ref so the load effect (which fires in
+        // the same commit) sees the cleared flags instead of stale `true`
+        // values from the previous entity.
+        loadedTabsRef.current = reset;
         setData([]);
         setOperations([]);
         setFaults([]);

--- a/src/components/UpdatesDashboard.test.tsx
+++ b/src/components/UpdatesDashboard.test.tsx
@@ -199,4 +199,54 @@ describe('UpdatesDashboard', () => {
 
         expect(toast.error).toHaveBeenCalled();
     });
+
+    it('passes an AbortSignal to mutation actions', async () => {
+        const user = userEvent.setup();
+        mockTriggerPrepare.mockResolvedValue(undefined);
+        mockUseUpdatesPolling.mockReturnValue(makeResult({ updates: [makeEntry('fw-v2', 'pending')] }));
+
+        render(<UpdatesDashboard />);
+
+        const prepareBtn = screen.getByRole('button', { name: /prepare/i });
+        await user.click(prepareBtn);
+
+        // triggerPrepare is called with (baseUrl, id, data, signal) - assert signal is an AbortSignal
+        const call = mockTriggerPrepare.mock.calls[0]!;
+        const signal = call[3];
+        expect(signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('aborts in-flight mutations on unmount', async () => {
+        const user = userEvent.setup();
+        let resolvePrepare: () => void = () => {};
+        mockTriggerPrepare.mockImplementation(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolvePrepare = resolve;
+                })
+        );
+        mockUseUpdatesPolling.mockReturnValue(makeResult({ updates: [makeEntry('fw-v2', 'pending')] }));
+        const { toast } = await import('react-toastify');
+        vi.mocked(toast.success).mockClear();
+
+        const { unmount } = render(<UpdatesDashboard />);
+
+        const prepareBtn = screen.getByRole('button', { name: /prepare/i });
+        await user.click(prepareBtn);
+
+        // Capture the signal before unmount
+        const signal = mockTriggerPrepare.mock.calls[0]![3] as AbortSignal;
+        expect(signal.aborted).toBe(false);
+
+        unmount();
+
+        expect(signal.aborted).toBe(true);
+
+        // Late-resolve the prepare call - must NOT fire a success toast on
+        // the unmounted component.
+        resolvePrepare();
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(toast.success).not.toHaveBeenCalled();
+    });
 });

--- a/src/components/UpdatesDashboard.tsx
+++ b/src/components/UpdatesDashboard.tsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { Package, RefreshCw, AlertTriangle, Server } from 'lucide-react';
 import { toast } from 'react-toastify';
@@ -39,6 +39,16 @@ export function UpdatesDashboard() {
     const { updates, isLoading, error, notAvailable, refresh } = useUpdatesPolling(baseUrl);
     const [busyIds, setBusyIds] = useState<Set<string>>(new Set());
 
+    // AbortController for mutation actions (prepare/execute/automated/delete).
+    // Aborted on unmount so in-flight requests don't resolve into setBusyIds
+    // on an unmounted component or issue stale toast notifications.
+    const actionAbortRef = useRef<AbortController | null>(null);
+    useEffect(() => {
+        const controller = new AbortController();
+        actionAbortRef.current = controller;
+        return () => controller.abort();
+    }, []);
+
     const summary = useMemo(() => {
         let active = 0;
         let failed = 0;
@@ -59,22 +69,27 @@ export function UpdatesDashboard() {
                 const confirmed = window.confirm(`Delete update "${id}"? This cannot be undone.`);
                 if (!confirmed) return;
             }
+            const signal = actionAbortRef.current?.signal;
             setBusyIds((prev) => new Set(prev).add(id));
             try {
-                if (action === 'prepare') await triggerPrepare(baseUrl, id);
-                else if (action === 'execute') await triggerExecute(baseUrl, id);
-                else if (action === 'automated') await triggerAutomated(baseUrl, id);
-                else if (action === 'delete') await deleteUpdate(baseUrl, id);
+                if (action === 'prepare') await triggerPrepare(baseUrl, id, undefined, signal);
+                else if (action === 'execute') await triggerExecute(baseUrl, id, undefined, signal);
+                else if (action === 'automated') await triggerAutomated(baseUrl, id, undefined, signal);
+                else if (action === 'delete') await deleteUpdate(baseUrl, id, signal);
+                if (signal?.aborted) return;
                 toast.success(`${action} triggered for ${id}`);
                 refresh();
             } catch (err) {
+                if (signal?.aborted || (err as { name?: string })?.name === 'AbortError') return;
                 toast.error(err instanceof Error ? err.message : String(err));
             } finally {
-                setBusyIds((prev) => {
-                    const next = new Set(prev);
-                    next.delete(id);
-                    return next;
-                });
+                if (!signal?.aborted) {
+                    setBusyIds((prev) => {
+                        const next = new Set(prev);
+                        next.delete(id);
+                        return next;
+                    });
+                }
             }
         },
         [baseUrl, refresh]

--- a/src/lib/api-dispatch.ts
+++ b/src/lib/api-dispatch.ts
@@ -46,19 +46,29 @@ export function getEntityDetail(client: MedkitClient, entityType: SovdResourceEn
 // Configurations
 // =============================================================================
 
-export function getEntityConfigurations(client: MedkitClient, entityType: SovdResourceEntityType, entityId: string) {
+export function getEntityConfigurations(
+    client: MedkitClient,
+    entityType: SovdResourceEntityType,
+    entityId: string,
+    signal?: AbortSignal
+) {
     switch (entityType) {
         case 'apps':
-            return client.GET('/apps/{app_id}/configurations', { params: { path: { app_id: entityId } } });
+            return client.GET('/apps/{app_id}/configurations', { params: { path: { app_id: entityId } }, signal });
         case 'components':
             return client.GET('/components/{component_id}/configurations', {
                 params: { path: { component_id: entityId } },
+                signal,
             });
         case 'areas':
-            return client.GET('/areas/{area_id}/configurations', { params: { path: { area_id: entityId } } });
+            return client.GET('/areas/{area_id}/configurations', {
+                params: { path: { area_id: entityId } },
+                signal,
+            });
         case 'functions':
             return client.GET('/functions/{function_id}/configurations', {
                 params: { path: { function_id: entityId } },
+                signal,
             });
     }
 }
@@ -167,16 +177,27 @@ export function deleteEntityConfigurations(client: MedkitClient, entityType: Sov
 // Data
 // =============================================================================
 
-export function getEntityData(client: MedkitClient, entityType: SovdResourceEntityType, entityId: string) {
+export function getEntityData(
+    client: MedkitClient,
+    entityType: SovdResourceEntityType,
+    entityId: string,
+    signal?: AbortSignal
+) {
     switch (entityType) {
         case 'apps':
-            return client.GET('/apps/{app_id}/data', { params: { path: { app_id: entityId } } });
+            return client.GET('/apps/{app_id}/data', { params: { path: { app_id: entityId } }, signal });
         case 'components':
-            return client.GET('/components/{component_id}/data', { params: { path: { component_id: entityId } } });
+            return client.GET('/components/{component_id}/data', {
+                params: { path: { component_id: entityId } },
+                signal,
+            });
         case 'areas':
-            return client.GET('/areas/{area_id}/data', { params: { path: { area_id: entityId } } });
+            return client.GET('/areas/{area_id}/data', { params: { path: { area_id: entityId } }, signal });
         case 'functions':
-            return client.GET('/functions/{function_id}/data', { params: { path: { function_id: entityId } } });
+            return client.GET('/functions/{function_id}/data', {
+                params: { path: { function_id: entityId } },
+                signal,
+            });
     }
 }
 
@@ -241,19 +262,29 @@ export function putEntityDataItem(
 // Operations
 // =============================================================================
 
-export function getEntityOperations(client: MedkitClient, entityType: SovdResourceEntityType, entityId: string) {
+export function getEntityOperations(
+    client: MedkitClient,
+    entityType: SovdResourceEntityType,
+    entityId: string,
+    signal?: AbortSignal
+) {
     switch (entityType) {
         case 'apps':
-            return client.GET('/apps/{app_id}/operations', { params: { path: { app_id: entityId } } });
+            return client.GET('/apps/{app_id}/operations', { params: { path: { app_id: entityId } }, signal });
         case 'components':
             return client.GET('/components/{component_id}/operations', {
                 params: { path: { component_id: entityId } },
+                signal,
             });
         case 'areas':
-            return client.GET('/areas/{area_id}/operations', { params: { path: { area_id: entityId } } });
+            return client.GET('/areas/{area_id}/operations', {
+                params: { path: { area_id: entityId } },
+                signal,
+            });
         case 'functions':
             return client.GET('/functions/{function_id}/operations', {
                 params: { path: { function_id: entityId } },
+                signal,
             });
     }
 }
@@ -359,19 +390,26 @@ export function deleteEntityExecution(
 // Faults
 // =============================================================================
 
-export function getEntityFaults(client: MedkitClient, entityType: SovdResourceEntityType, entityId: string) {
+export function getEntityFaults(
+    client: MedkitClient,
+    entityType: SovdResourceEntityType,
+    entityId: string,
+    signal?: AbortSignal
+) {
     switch (entityType) {
         case 'apps':
-            return client.GET('/apps/{app_id}/faults', { params: { path: { app_id: entityId } } });
+            return client.GET('/apps/{app_id}/faults', { params: { path: { app_id: entityId } }, signal });
         case 'components':
             return client.GET('/components/{component_id}/faults', {
                 params: { path: { component_id: entityId } },
+                signal,
             });
         case 'areas':
-            return client.GET('/areas/{area_id}/faults', { params: { path: { area_id: entityId } } });
+            return client.GET('/areas/{area_id}/faults', { params: { path: { area_id: entityId } }, signal });
         case 'functions':
             return client.GET('/functions/{function_id}/faults', {
                 params: { path: { function_id: entityId } },
+                signal,
             });
     }
 }

--- a/src/lib/store-helpers.test.ts
+++ b/src/lib/store-helpers.test.ts
@@ -20,6 +20,7 @@ import {
     inferEntityTypeFromDepth,
     parseTreePath,
     filterAppsByComponent,
+    isPeerSourcedComponent,
 } from './store';
 import type { SovdEntity, EntityTreeNode } from './types';
 
@@ -425,9 +426,15 @@ describe('filterAppsByComponent', () => {
         { id: 'local-app', 'x-medkit': { component_id: 'ecu-primary' } },
         { id: 'data_viewer', 'x-medkit': { component_id: 'ecu-rtmaps' } },
         { id: 'lidar_sim', _links: { 'is-located-on': '/api/v1/components/ecu-rtmaps' } },
+        { id: 'top-level-app', component_id: 'ecu-tesla' },
         { id: 'orphan-app', 'x-medkit': {} },
         { id: 'bare-app' },
     ];
+
+    it('matches apps by top-level component_id', () => {
+        const result = filterAppsByComponent(apps, 'ecu-tesla');
+        expect(result.map((a) => a.id)).toEqual(['top-level-app']);
+    });
 
     it('matches apps by x-medkit.component_id', () => {
         const result = filterAppsByComponent(apps, 'ecu-primary');
@@ -455,5 +462,28 @@ describe('filterAppsByComponent', () => {
         ];
         const result = filterAppsByComponent(tricky, 'ecu-rtmaps');
         expect(result).toEqual([]);
+    });
+});
+
+// =============================================================================
+// isPeerSourcedComponent
+// =============================================================================
+
+describe('isPeerSourcedComponent', () => {
+    it('returns true for peer-sourced components', () => {
+        expect(isPeerSourcedComponent({ 'x-medkit': { source: 'peer:ecu-rtmaps' } })).toBe(true);
+    });
+
+    it('returns false for manifest-sourced components', () => {
+        expect(isPeerSourcedComponent({ 'x-medkit': { source: 'manifest' } })).toBe(false);
+    });
+
+    it('returns false for plugin-sourced components', () => {
+        expect(isPeerSourcedComponent({ 'x-medkit': { source: 'plugin' } })).toBe(false);
+    });
+
+    it('returns true when source metadata is missing (err on the side of completeness)', () => {
+        expect(isPeerSourcedComponent({})).toBe(true);
+        expect(isPeerSourcedComponent({ 'x-medkit': {} })).toBe(true);
     });
 });

--- a/src/lib/store-helpers.test.ts
+++ b/src/lib/store-helpers.test.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
     toTreeNode,
     updateNodeInTree,
@@ -21,8 +21,11 @@ import {
     parseTreePath,
     filterAppsByComponent,
     isPeerSourcedComponent,
+    fetchAllAppsDeduped,
+    __resetAppsRequestCache,
 } from './store';
 import type { SovdEntity, EntityTreeNode } from './types';
+import type { MedkitClient } from '@selfpatch/ros2-medkit-client-ts';
 
 // =============================================================================
 // Helper factories
@@ -462,6 +465,59 @@ describe('filterAppsByComponent', () => {
         ];
         const result = filterAppsByComponent(tricky, 'ecu-rtmaps');
         expect(result).toEqual([]);
+    });
+});
+
+// =============================================================================
+// fetchAllAppsDeduped
+// =============================================================================
+
+describe('fetchAllAppsDeduped', () => {
+    beforeEach(() => {
+        __resetAppsRequestCache();
+    });
+
+    it('shares one in-flight request across concurrent calls', async () => {
+        let resolveGet: (value: { data: { items: Record<string, unknown>[] } }) => void = () => {};
+        const getSpy = vi.fn(
+            () =>
+                new Promise<{ data: { items: Record<string, unknown>[] } }>((resolve) => {
+                    resolveGet = resolve;
+                })
+        );
+        const client = { GET: getSpy } as unknown as MedkitClient;
+
+        // Fire three concurrent callers
+        const p1 = fetchAllAppsDeduped(client);
+        const p2 = fetchAllAppsDeduped(client);
+        const p3 = fetchAllAppsDeduped(client);
+
+        // Exactly one underlying HTTP call
+        expect(getSpy).toHaveBeenCalledTimes(1);
+
+        // Resolve and verify all three callers receive the same data
+        const apps = [{ id: 'one' }, { id: 'two' }];
+        resolveGet({ data: { items: apps } });
+        await expect(p1).resolves.toEqual(apps);
+        await expect(p2).resolves.toEqual(apps);
+        await expect(p3).resolves.toEqual(apps);
+    });
+
+    it('clears cache after settle so the next caller refetches', async () => {
+        const getSpy = vi.fn().mockResolvedValue({ data: { items: [{ id: 'a' }] } });
+        const client = { GET: getSpy } as unknown as MedkitClient;
+
+        await fetchAllAppsDeduped(client);
+        await fetchAllAppsDeduped(client);
+
+        expect(getSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns empty array on fetch failure', async () => {
+        const getSpy = vi.fn().mockRejectedValue(new Error('network down'));
+        const client = { GET: getSpy } as unknown as MedkitClient;
+
+        await expect(fetchAllAppsDeduped(client)).resolves.toEqual([]);
     });
 });
 

--- a/src/lib/store-helpers.test.ts
+++ b/src/lib/store-helpers.test.ts
@@ -13,7 +13,14 @@
 // limitations under the License.
 
 import { describe, it, expect } from 'vitest';
-import { toTreeNode, updateNodeInTree, findNode, inferEntityTypeFromDepth, parseTreePath } from './store';
+import {
+    toTreeNode,
+    updateNodeInTree,
+    findNode,
+    inferEntityTypeFromDepth,
+    parseTreePath,
+    filterAppsByComponent,
+} from './store';
 import type { SovdEntity, EntityTreeNode } from './types';
 
 // =============================================================================
@@ -406,5 +413,47 @@ describe('parseTreePath', () => {
         const result = parseTreePath('/server/chassis');
         expect(result.entityType).toBe('areas');
         expect(result.entityId).toBe('chassis');
+    });
+});
+
+// =============================================================================
+// filterAppsByComponent
+// =============================================================================
+
+describe('filterAppsByComponent', () => {
+    const apps: Record<string, unknown>[] = [
+        { id: 'local-app', 'x-medkit': { component_id: 'ecu-primary' } },
+        { id: 'data_viewer', 'x-medkit': { component_id: 'ecu-rtmaps' } },
+        { id: 'lidar_sim', _links: { 'is-located-on': '/api/v1/components/ecu-rtmaps' } },
+        { id: 'orphan-app', 'x-medkit': {} },
+        { id: 'bare-app' },
+    ];
+
+    it('matches apps by x-medkit.component_id', () => {
+        const result = filterAppsByComponent(apps, 'ecu-primary');
+        expect(result.map((a) => a.id)).toEqual(['local-app']);
+    });
+
+    it('matches apps by _links.is-located-on', () => {
+        const result = filterAppsByComponent(apps, 'ecu-rtmaps');
+        expect(result.map((a) => a.id)).toEqual(['data_viewer', 'lidar_sim']);
+    });
+
+    it('returns empty array when no apps match', () => {
+        const result = filterAppsByComponent(apps, 'nonexistent');
+        expect(result).toEqual([]);
+    });
+
+    it('handles empty apps list', () => {
+        const result = filterAppsByComponent([], 'ecu-primary');
+        expect(result).toEqual([]);
+    });
+
+    it('does not match partial component ID in _links', () => {
+        const tricky: Record<string, unknown>[] = [
+            { id: 'partial', _links: { 'is-located-on': '/api/v1/components/ecu-rtmaps-extended' } },
+        ];
+        const result = filterAppsByComponent(tricky, 'ecu-rtmaps');
+        expect(result).toEqual([]);
     });
 });

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -613,6 +613,22 @@ export function parseTreePath(path: string): {
     return { entityType, entityId };
 }
 
+/**
+ * Filter apps that belong to a given component by checking
+ * `x-medkit.component_id` or `_links.is-located-on`.
+ *
+ * Used as a fallback when `/components/{id}/hosts` returns empty
+ * (peer-sourced components).
+ */
+export function filterAppsByComponent(apps: Record<string, unknown>[], componentId: string): Record<string, unknown>[] {
+    return apps.filter((app) => {
+        const xMedkit = app['x-medkit'] as Record<string, unknown> | undefined;
+        if (xMedkit?.component_id === componentId) return true;
+        const links = app['_links'] as Record<string, string> | undefined;
+        return links?.['is-located-on']?.endsWith(`/components/${componentId}`);
+    });
+}
+
 /** Fallback: fetch entity details from API when not in tree */
 async function fetchEntityFromApi(
     path: string,
@@ -995,7 +1011,19 @@ export const useAppStore = create<AppState>()(
                             );
                             const subcompNodes = subcomponents.map((e: SovdEntity) => toTreeNode(e, path));
 
-                            const rawApps = appsRes.data ? unwrapItems<Record<string, unknown>>(appsRes.data) : [];
+                            let rawApps = appsRes.data ? unwrapItems<Record<string, unknown>>(appsRes.data) : [];
+
+                            // Fallback for peer-sourced components: /hosts may return
+                            // empty while apps still reference this component via
+                            // x-medkit.component_id. Fetch all apps and filter.
+                            if (rawApps.length === 0) {
+                                const allAppsRes = await client.GET('/apps').catch(() => ({ data: undefined }));
+                                const allApps = allAppsRes.data
+                                    ? unwrapItems<Record<string, unknown>>(allAppsRes.data)
+                                    : [];
+                                rawApps = filterAppsByComponent(allApps, node.id);
+                            }
+
                             const apps = rawApps.map((e) => ({ ...e, type: 'app' }) as unknown as SovdEntity);
                             const appNodes = apps.map((app: SovdEntity) =>
                                 toTreeNode({ ...app, type: 'app', hasChildren: false }, path)

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -120,7 +120,7 @@ export interface AppState {
     clearSelection: () => void;
 
     // Configurations actions
-    fetchConfigurations: (entityId: string, entityType?: SovdResourceEntityType) => Promise<void>;
+    fetchConfigurations: (entityId: string, entityType?: SovdResourceEntityType, signal?: AbortSignal) => Promise<void>;
     setParameter: (
         entityId: string,
         paramName: string,
@@ -164,11 +164,20 @@ export interface AppState {
     unsubscribeFaultStream: () => void;
 
     // Component-facing actions (replace direct client usage in components)
-    fetchEntityData: (entityType: SovdResourceEntityType, entityId: string) => Promise<ComponentTopic[]>;
-    fetchEntityOperations: (entityType: SovdResourceEntityType, entityId: string) => Promise<Operation[]>;
+    fetchEntityData: (
+        entityType: SovdResourceEntityType,
+        entityId: string,
+        signal?: AbortSignal
+    ) => Promise<ComponentTopic[]>;
+    fetchEntityOperations: (
+        entityType: SovdResourceEntityType,
+        entityId: string,
+        signal?: AbortSignal
+    ) => Promise<Operation[]>;
     listEntityFaults: (
         entityType: SovdResourceEntityType,
-        entityId: string
+        entityId: string,
+        signal?: AbortSignal
     ) => Promise<{ items: Fault[]; count: number }>;
     fetchEntityLogs: (
         entityType: SovdResourceEntityType,
@@ -647,6 +656,34 @@ export function isPeerSourcedComponent(node: Record<string, unknown>): boolean {
     return source.startsWith('peer:');
 }
 
+/**
+ * Module-level dedupe for `GET /apps`. When multiple peer-sourced
+ * components are expanded concurrently, each needs the full apps list
+ * for its fallback; without dedupe that would trigger N identical
+ * requests. Holding the in-flight promise here collapses them into one.
+ *
+ * The promise is cleared on settlement so subsequent expansions refetch
+ * fresh data (no stale caching across time).
+ */
+let inFlightAppsRequest: Promise<Record<string, unknown>[]> | null = null;
+
+/** Reset the dedupe cache. Exposed for tests. */
+export function __resetAppsRequestCache(): void {
+    inFlightAppsRequest = null;
+}
+
+export async function fetchAllAppsDeduped(client: MedkitClient): Promise<Record<string, unknown>[]> {
+    if (inFlightAppsRequest) return inFlightAppsRequest;
+    inFlightAppsRequest = client
+        .GET('/apps')
+        .then((res) => (res.data ? unwrapItems<Record<string, unknown>>(res.data) : []))
+        .catch(() => [] as Record<string, unknown>[])
+        .finally(() => {
+            inFlightAppsRequest = null;
+        });
+    return inFlightAppsRequest;
+}
+
 /** Fallback: fetch entity details from API when not in tree */
 async function fetchEntityFromApi(
     path: string,
@@ -1037,14 +1074,13 @@ export const useAppStore = create<AppState>()(
                             // Gated on isPeerSourcedComponent so we don't pay the
                             // full /apps fetch for components that legitimately
                             // have no apps (e.g. manifest or plugin components).
+                            // Uses fetchAllAppsDeduped so concurrent expansions of
+                            // multiple peer components share a single /apps request.
                             if (
                                 rawApps.length === 0 &&
                                 isPeerSourcedComponent(node as unknown as Record<string, unknown>)
                             ) {
-                                const allAppsRes = await client.GET('/apps').catch(() => ({ data: undefined }));
-                                const allApps = allAppsRes.data
-                                    ? unwrapItems<Record<string, unknown>>(allAppsRes.data)
-                                    : [];
+                                const allApps = await fetchAllAppsDeduped(client);
                                 rawApps = filterAppsByComponent(allApps, node.id);
                             }
 
@@ -1325,20 +1361,34 @@ export const useAppStore = create<AppState>()(
             // CONFIGURATIONS ACTIONS (ROS 2 Parameters)
             // ===========================================================================
 
-            fetchConfigurations: async (entityId: string, entityType: SovdResourceEntityType = 'components') => {
+            fetchConfigurations: async (
+                entityId: string,
+                entityType: SovdResourceEntityType = 'components',
+                signal?: AbortSignal
+            ) => {
                 const { client, configurations } = get();
                 if (!client) return;
 
                 set({ isLoadingConfigurations: true });
 
                 try {
-                    const { data, error: fetchError } = await getEntityConfigurations(client, entityType, entityId);
+                    const { data, error: fetchError } = await getEntityConfigurations(
+                        client,
+                        entityType,
+                        entityId,
+                        signal
+                    );
+                    if (signal?.aborted) return;
                     if (fetchError) throw new Error(fetchError.message || 'Failed to load configurations');
                     const result = transformConfigurationsResponse(data, entityId);
                     const newConfigs = new Map(configurations);
                     newConfigs.set(entityId, result.parameters);
                     set({ configurations: newConfigs, isLoadingConfigurations: false });
                 } catch (error) {
+                    if (signal?.aborted || (error instanceof DOMException && error.name === 'AbortError')) {
+                        set({ isLoadingConfigurations: false });
+                        return;
+                    }
                     const message = error instanceof Error ? error.message : 'Unknown error';
                     console.error('[store]', error);
                     toast.error(`Failed to load configurations: ${message}`);
@@ -1899,26 +1949,30 @@ export const useAppStore = create<AppState>()(
             // COMPONENT-FACING ACTIONS (replace direct client usage)
             // =================================================================
 
-            fetchEntityData: async (entityType: SovdResourceEntityType, entityId: string) => {
+            fetchEntityData: async (entityType: SovdResourceEntityType, entityId: string, signal?: AbortSignal) => {
                 const { client } = get();
                 if (!client) return [];
-                const { data, error: fetchError } = await getEntityData(client, entityType, entityId);
+                const { data, error: fetchError } = await getEntityData(client, entityType, entityId, signal);
                 if (fetchError) return [];
                 return transformDataResponse(data);
             },
 
-            fetchEntityOperations: async (entityType: SovdResourceEntityType, entityId: string) => {
+            fetchEntityOperations: async (
+                entityType: SovdResourceEntityType,
+                entityId: string,
+                signal?: AbortSignal
+            ) => {
                 const { client } = get();
                 if (!client) return [];
-                const { data, error: fetchError } = await getEntityOperations(client, entityType, entityId);
+                const { data, error: fetchError } = await getEntityOperations(client, entityType, entityId, signal);
                 if (fetchError) return [];
                 return transformOperationsResponse(data);
             },
 
-            listEntityFaults: async (entityType: SovdResourceEntityType, entityId: string) => {
+            listEntityFaults: async (entityType: SovdResourceEntityType, entityId: string, signal?: AbortSignal) => {
                 const { client } = get();
                 if (!client) return { items: [], count: 0 };
-                const { data, error: fetchError } = await getEntityFaults(client, entityType, entityId);
+                const { data, error: fetchError } = await getEntityFaults(client, entityType, entityId, signal);
                 if (fetchError) return { items: [], count: 0 };
                 return transformFaultsResponse(data);
             },

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -615,18 +615,36 @@ export function parseTreePath(path: string): {
 
 /**
  * Filter apps that belong to a given component by checking
- * `x-medkit.component_id` or `_links.is-located-on`.
+ * the top-level `component_id` field, `x-medkit.component_id`,
+ * or `_links.is-located-on`.
  *
  * Used as a fallback when `/components/{id}/hosts` returns empty
  * (peer-sourced components).
  */
 export function filterAppsByComponent(apps: Record<string, unknown>[], componentId: string): Record<string, unknown>[] {
     return apps.filter((app) => {
+        if (app['component_id'] === componentId) return true;
         const xMedkit = app['x-medkit'] as Record<string, unknown> | undefined;
         if (xMedkit?.component_id === componentId) return true;
         const links = app['_links'] as Record<string, string> | undefined;
         return links?.['is-located-on']?.endsWith(`/components/${componentId}`);
     });
+}
+
+/**
+ * Detect whether a component node is peer-sourced (aggregated from a
+ * remote gateway). Peer-sourced components have `x-medkit.source`
+ * starting with `"peer:"`.
+ *
+ * Components with unknown source metadata are treated as peer-sourced
+ * so the fallback still discovers their apps; this errs on the side of
+ * completeness over saving one extra request.
+ */
+export function isPeerSourcedComponent(node: Record<string, unknown>): boolean {
+    const xMedkit = node['x-medkit'] as Record<string, unknown> | undefined;
+    const source = xMedkit?.source;
+    if (typeof source !== 'string') return true;
+    return source.startsWith('peer:');
 }
 
 /** Fallback: fetch entity details from API when not in tree */
@@ -1016,7 +1034,13 @@ export const useAppStore = create<AppState>()(
                             // Fallback for peer-sourced components: /hosts may return
                             // empty while apps still reference this component via
                             // x-medkit.component_id. Fetch all apps and filter.
-                            if (rawApps.length === 0) {
+                            // Gated on isPeerSourcedComponent so we don't pay the
+                            // full /apps fetch for components that legitimately
+                            // have no apps (e.g. manifest or plugin components).
+                            if (
+                                rawApps.length === 0 &&
+                                isPeerSourcedComponent(node as unknown as Record<string, unknown>)
+                            ) {
                                 const allAppsRes = await client.GET('/apps').catch(() => ({ data: undefined }));
                                 const allApps = allAppsRes.data
                                     ? unwrapItems<Record<string, unknown>>(allAppsRes.data)


### PR DESCRIPTION
## Summary

Fix two bugs that broke the entity browser when connected to a gateway aggregating peer ECUs:

- **EntityResourceTabs** showed empty content for Data/Operations/Configurations/Faults tabs after switching between entities, because the reset effect updated `loadedTabs` via batched setState but the load effect in the same React commit read a stale `loadedTabsRef` and returned early.
- **Peer-sourced components** (sourced from remote gateways via aggregation) showed no child apps because `GET /components/{id}/hosts` returns empty for them; the child apps actually reference the component via `x-medkit.component_id` or `_links.is-located-on`.

---

## Issue

- closes #61

---

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- 7 new unit tests: 2 for `EntityResourceTabs` entity-switch behavior, 5 for the new `filterAppsByComponent` helper (covering both match criteria, empty input, and the partial-ID edge case where a suffix of a longer component ID must not match).
- Full suite: 297 tests pass (was 290).
- Typecheck and lint clean.
- Reviewers should verify manually: connect the UI to a gateway with a peer component, expand it, and check that child apps appear; switch between sibling components and verify each tab's content refreshes.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Docs were updated if behavior or public API changed