### PR TITLE
fix(UpdateCard): render Execute when status=completed + x-medkit-phase=prepared

### DIFF
--- a/src/components/UpdateCard.test.tsx
+++ b/src/components/UpdateCard.test.tsx
@@ -16,7 +16,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { UpdateCard } from './UpdateCard';
-import type { UpdateEntry } from '@/lib/types';
+import type { UpdateEntry, UpdatePhase } from '@/lib/types';
 
 describe('UpdateCard', () => {
     it('renders update ID', () => {
@@ -92,9 +92,9 @@ describe('UpdateCard', () => {
     });
 
     it('surfaces Execute alongside Delete when completed maps to phase=prepared', () => {
-        // uptane_ota and similar plugins split prepare/execute but expose both
-        // terminal states as SOVD status=completed. The phase disambiguates:
-        // completed + prepared means the install still needs to run.
+        // Plugins that split prepare/execute expose both terminal states as
+        // SOVD status=completed. The phase disambiguates: completed +
+        // prepared means the install still needs to run.
         const entry: UpdateEntry = {
             id: 'update-prepared',
             status: { status: 'completed', 'x-medkit-phase': 'prepared' },
@@ -115,6 +115,36 @@ describe('UpdateCard', () => {
         render(<UpdateCard entry={entry} onAction={vi.fn()} />);
 
         expect(screen.queryByRole('button', { name: /^execute$/i })).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    });
+
+    it('falls back to Delete-only when completed carries an unknown phase', () => {
+        // Contract: only `prepared` surfaces Execute. Any other (or
+        // out-of-enum) phase on `completed` is treated as terminal.
+        const entry: UpdateEntry = {
+            id: 'update-unknown-phase',
+            status: {
+                status: 'completed',
+                'x-medkit-phase': 'installing' as UpdatePhase,
+            },
+        };
+
+        render(<UpdateCard entry={entry} onAction={vi.fn()} />);
+
+        expect(screen.queryByRole('button', { name: /^execute$/i })).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    });
+
+    it('ignores phase on failed updates and offers the retry actions', () => {
+        const entry: UpdateEntry = {
+            id: 'update-failed-after-prepare',
+            status: { status: 'failed', 'x-medkit-phase': 'prepared' },
+        };
+
+        render(<UpdateCard entry={entry} onAction={vi.fn()} />);
+
+        expect(screen.getByRole('button', { name: /prepare/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^execute$/i })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
     });
 

--- a/src/components/UpdateCard.test.tsx
+++ b/src/components/UpdateCard.test.tsx
@@ -79,6 +79,45 @@ describe('UpdateCard', () => {
         expect(screen.getByText('completed')).toBeInTheDocument();
     });
 
+    it('only offers Delete when an update completed with no x-medkit-phase', () => {
+        const entry: UpdateEntry = {
+            id: 'update-done',
+            status: { status: 'completed' },
+        };
+
+        render(<UpdateCard entry={entry} onAction={vi.fn()} />);
+
+        expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: /^execute$/i })).not.toBeInTheDocument();
+    });
+
+    it('surfaces Execute alongside Delete when completed maps to phase=prepared', () => {
+        // uptane_ota and similar plugins split prepare/execute but expose both
+        // terminal states as SOVD status=completed. The phase disambiguates:
+        // completed + prepared means the install still needs to run.
+        const entry: UpdateEntry = {
+            id: 'update-prepared',
+            status: { status: 'completed', 'x-medkit-phase': 'prepared' },
+        };
+
+        render(<UpdateCard entry={entry} onAction={vi.fn()} />);
+
+        expect(screen.getByRole('button', { name: /^execute$/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    });
+
+    it('drops Execute once phase advances past prepared', () => {
+        const entry: UpdateEntry = {
+            id: 'update-executed',
+            status: { status: 'completed', 'x-medkit-phase': 'executed' },
+        };
+
+        render(<UpdateCard entry={entry} onAction={vi.fn()} />);
+
+        expect(screen.queryByRole('button', { name: /^execute$/i })).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument();
+    });
+
     it('shows failed badge with error message text', () => {
         const entry: UpdateEntry = {
             id: 'update-failed',

--- a/src/components/UpdateCard.tsx
+++ b/src/components/UpdateCard.tsx
@@ -19,7 +19,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Package, Loader2, AlertCircle, FileText } from 'lucide-react';
 import { fetchUpdateDetail } from '@/lib/updates-api';
-import type { UpdateEntry, UpdateStatusValue } from '@/lib/types';
+import type { UpdateEntry, UpdateStatus, UpdateStatusValue } from '@/lib/types';
 
 export type UpdateAction = 'prepare' | 'execute' | 'automated' | 'delete';
 
@@ -58,14 +58,21 @@ function progressBarColor(status: UpdateStatusValue): string {
     }
 }
 
-function actionButtonsForStatus(status: UpdateStatusValue): UpdateAction[] {
-    switch (status) {
+function actionButtonsForStatus(status: UpdateStatus): UpdateAction[] {
+    // SOVD collapses the prepare + execute pipeline into a single
+    // `completed` terminal status. Plugins that split the pipeline (e.g.
+    // uptane_ota) keep the real phase on the `x-medkit-phase` vendor field,
+    // so when status=completed + phase=prepared we are only half done and
+    // must surface Execute / Delete. Any other completed update (phase
+    // missing or `executed`) is truly terminal and only Delete applies.
+    const phase = status['x-medkit-phase'];
+    switch (status.status) {
         case 'pending':
             return ['prepare', 'execute', 'automated', 'delete'];
         case 'inProgress':
             return [];
         case 'completed':
-            return ['delete'];
+            return phase === 'prepared' ? ['execute', 'delete'] : ['delete'];
         case 'failed':
             return ['prepare', 'execute', 'delete'];
     }
@@ -213,7 +220,7 @@ export function UpdateCard({ entry, baseUrl, busy, onAction }: UpdateCardProps) 
 
                         <div className="flex flex-wrap gap-2 pt-1">
                             {onAction &&
-                                actionButtonsForStatus(status.status).map((action) => (
+                                actionButtonsForStatus(status).map((action) => (
                                     <Button
                                         key={action}
                                         size="sm"

--- a/src/components/UpdateCard.tsx
+++ b/src/components/UpdateCard.tsx
@@ -60,11 +60,13 @@ function progressBarColor(status: UpdateStatusValue): string {
 
 function actionButtonsForStatus(status: UpdateStatus): UpdateAction[] {
     // SOVD collapses the prepare + execute pipeline into a single
-    // `completed` terminal status. Plugins that split the pipeline (e.g.
-    // uptane_ota) keep the real phase on the `x-medkit-phase` vendor field,
-    // so when status=completed + phase=prepared we are only half done and
-    // must surface Execute / Delete. Any other completed update (phase
-    // missing or `executed`) is truly terminal and only Delete applies.
+    // `completed` terminal status. Plugins that split the pipeline keep the
+    // real phase on the `x-medkit-phase` vendor field, so when
+    // status=completed + phase=prepared we are only half done and must
+    // surface Execute / Delete. Any other completed update (phase missing
+    // or `executed`) is truly terminal and only Delete applies. The
+    // `default` keeps the UI safe if a plugin emits a status outside the
+    // documented enum.
     const phase = status['x-medkit-phase'];
     switch (status.status) {
         case 'pending':
@@ -75,6 +77,8 @@ function actionButtonsForStatus(status: UpdateStatus): UpdateAction[] {
             return phase === 'prepared' ? ['execute', 'delete'] : ['delete'];
         case 'failed':
             return ['prepare', 'execute', 'delete'];
+        default:
+            return ['delete'];
     }
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -957,12 +957,21 @@ export interface UpdateSubProgress {
 
 /**
  * Status response from GET /updates/{id}/status
+ *
+ * `x-medkit-phase` is a gateway-specific vendor extension used by OTA
+ * plugins (e.g. uptane_ota) that split the lifecycle into two SOVD-visible
+ * terminal states: `prepared` (ready for Execute) and `executed` (install
+ * actually applied). Plain SOVD collapses both into `status: "completed"`,
+ * so without the phase the UI cannot tell a prepared update apart from a
+ * fully installed one. Optional because plugins that run the pipeline in
+ * one shot do not emit it.
  */
 export interface UpdateStatus {
     status: UpdateStatusValue;
     progress?: number; // 0-100
     sub_progress?: UpdateSubProgress[];
     error?: string;
+    'x-medkit-phase'?: string;
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -948,6 +948,13 @@ export interface TokenRevokeRequest {
 export type UpdateStatusValue = 'pending' | 'inProgress' | 'completed' | 'failed';
 
 /**
+ * Lifecycle phase for an update, carried on the gateway-specific vendor
+ * extension `x-medkit-phase`. See `docs/api/rest.rst` in the gateway repo
+ * for the authoritative contract.
+ */
+export type UpdatePhase = 'none' | 'preparing' | 'prepared' | 'executing' | 'executed' | 'failed' | 'deleting';
+
+/**
  * Sub-step progress for an update operation
  */
 export interface UpdateSubProgress {
@@ -959,19 +966,19 @@ export interface UpdateSubProgress {
  * Status response from GET /updates/{id}/status
  *
  * `x-medkit-phase` is a gateway-specific vendor extension used by OTA
- * plugins (e.g. uptane_ota) that split the lifecycle into two SOVD-visible
- * terminal states: `prepared` (ready for Execute) and `executed` (install
- * actually applied). Plain SOVD collapses both into `status: "completed"`,
- * so without the phase the UI cannot tell a prepared update apart from a
- * fully installed one. Optional because plugins that run the pipeline in
- * one shot do not emit it.
+ * plugins that split the lifecycle into two SOVD-visible terminal states:
+ * `prepared` (ready for Execute) and `executed` (install actually applied).
+ * Plain SOVD collapses both into `status: "completed"`, so without the
+ * phase the UI cannot tell a prepared update apart from a fully installed
+ * one. Optional because plugins that run the pipeline in one shot do not
+ * emit it.
  */
 export interface UpdateStatus {
     status: UpdateStatusValue;
     progress?: number; // 0-100
     sub_progress?: UpdateSubProgress[];
     error?: string;
-    'x-medkit-phase'?: string;
+    'x-medkit-phase'?: UpdatePhase;
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## Summary

Teach \`UpdateCard\` that \`status=completed\` is not always terminal: when the gateway's \`x-medkit-phase\` vendor extension reports \`prepared\`, the prepare step finished but execute still needs to run, so the card must offer **Execute** / **Delete** rather than only **Delete**.

- Add the optional \`x-medkit-phase\` field to \`UpdateStatus\`.
- Pass the full \`UpdateStatus\` into \`actionButtonsForStatus\` and branch on the phase inside the \`completed\` case.
- Add Vitest coverage for phase-missing (legacy/one-shot plugins), \`phase=prepared\`, and \`phase=executed\`.

Behavior for plugins that run the pipeline in one shot (no phase field) is unchanged.

---

## Issue

- closes #71

---

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- \`npm run lint\` passes.
- \`npm run build\` passes.
- \`npm test\` passes (401 tests), including the three new cases added to \`src/components/UpdateCard.test.tsx\`.

Manual check: register an update, click Prepare, wait for \`status=completed\` + \`x-medkit-phase=prepared\` on \`GET /updates/{id}/status\`; the card now shows Execute and Delete. After Execute resolves with \`x-medkit-phase=executed\`, only Delete remains.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed) - no breaking changes
- [x] Linting passes (\`npm run lint\`)
- [x] Build succeeds (\`npm run build\`)
- [x] Docs were updated if behavior or public API changed - \`UpdateStatus\` TSDoc updated to describe the new field