### PR TITLE
refactor(store): dedupe node-type maps, cover resolveParentEntityType

### DIFF
--- a/src/lib/store-helpers.test.ts
+++ b/src/lib/store-helpers.test.ts
@@ -19,6 +19,7 @@ import {
     findNode,
     inferEntityTypeFromDepth,
     parseTreePath,
+    resolveParentEntityType,
     filterAppsByComponent,
     isPeerSourcedComponent,
     fetchAllAppsDeduped,
@@ -417,6 +418,66 @@ describe('parseTreePath', () => {
         const result = parseTreePath('/server/chassis');
         expect(result.entityType).toBe('areas');
         expect(result.entityId).toBe('chassis');
+    });
+});
+
+// =============================================================================
+// resolveParentEntityType
+// =============================================================================
+
+describe('resolveParentEntityType', () => {
+    // runtime_only (function/app) hierarchy: the app sits at depth 2, where
+    // depth-based inference would wrongly label it a component.
+    const runtimeOnlyTree: EntityTreeNode[] = [
+        makeTreeNode({
+            id: 'navigation',
+            type: 'function',
+            path: '/server/navigation',
+            children: [makeTreeNode({ id: 'planner', type: 'app', path: '/server/navigation/planner' })],
+        }),
+    ];
+
+    it('resolves an app parent to "apps" regardless of tree depth', () => {
+        // Regression for the runtime_only 400: depth inference returned 'components'.
+        expect(resolveParentEntityType('/server/navigation/planner/data/cmd_vel', runtimeOnlyTree)).toBe('apps');
+    });
+
+    it('resolves a function parent to "functions"', () => {
+        expect(resolveParentEntityType('/server/navigation/faults/E_STOP', runtimeOnlyTree)).toBe('functions');
+    });
+
+    it('resolves a component parent to "components"', () => {
+        const tree = [makeTreeNode({ id: 'engine', type: 'component', path: '/server/powertrain/engine' })];
+        expect(resolveParentEntityType('/server/powertrain/engine/data/rpm', tree)).toBe('components');
+    });
+
+    it('resolves an area parent to "areas"', () => {
+        const tree = [makeTreeNode({ id: 'powertrain', type: 'area', path: '/server/powertrain' })];
+        expect(resolveParentEntityType('/server/powertrain/operations/reset', tree)).toBe('areas');
+    });
+
+    it('matches the node type case-insensitively', () => {
+        const tree = [makeTreeNode({ id: 'planner', type: 'App', path: '/server/navigation/planner' })];
+        expect(resolveParentEntityType('/server/navigation/planner/data/cmd_vel', tree)).toBe('apps');
+    });
+
+    it('resolves operations, configurations and faults resource segments', () => {
+        for (const resource of ['operations', 'configurations', 'faults']) {
+            expect(resolveParentEntityType(`/server/navigation/planner/${resource}/x`, runtimeOnlyTree)).toBe('apps');
+        }
+    });
+
+    it('returns undefined when the path has no resource segment', () => {
+        expect(resolveParentEntityType('/server/navigation/planner', runtimeOnlyTree)).toBeUndefined();
+    });
+
+    it('returns undefined when the parent node is not in the loaded tree', () => {
+        expect(resolveParentEntityType('/server/unknown/missing/data/topic', runtimeOnlyTree)).toBeUndefined();
+    });
+
+    it('returns undefined when the parent node type is unknown', () => {
+        const tree = [makeTreeNode({ id: 'mystery', type: 'gadget', path: '/server/mystery' })];
+        expect(resolveParentEntityType('/server/mystery/data/topic', tree)).toBeUndefined();
     });
 });
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -302,6 +302,36 @@ export function findNode(nodes: EntityTreeNode[], path: string): EntityTreeNode 
     return null;
 }
 
+/**
+ * Maps a tree node's singular `type` (e.g. "app", "function") to the plural
+ * SOVD resource keyword used in API routes (/apps, /functions, ...).
+ */
+const NODE_TYPE_TO_RESOURCE: Record<string, SovdResourceEntityType> = {
+    area: 'areas',
+    subarea: 'areas',
+    component: 'components',
+    subcomponent: 'components',
+    app: 'apps',
+    function: 'functions',
+};
+
+/**
+ * Finds the parent entity node for a resource path (/.../data/<id>, etc.) and
+ * returns its SOVD resource type. Returns undefined if the parent isn't in the
+ * loaded tree or its type is unknown.
+ */
+export function resolveParentEntityType(
+    path: string,
+    rootEntities: EntityTreeNode[]
+): SovdResourceEntityType | undefined {
+    const match = path.match(/^(.*?)\/(data|operations|configurations|faults)(?:\/.*?)?$/);
+    if (!match) return undefined;
+    const parentPath = match[1]!;
+    const parentNode = findNode(rootEntities, parentPath);
+    if (!parentNode) return undefined;
+    return NODE_TYPE_TO_RESOURCE[parentNode.type.toLowerCase()];
+}
+
 // =============================================================================
 // Entity Selection Handlers
 // =============================================================================
@@ -342,8 +372,7 @@ async function handleTopicSelection(ctx: SelectionContext, client: MedkitClient)
         // Find parent entity by walking up the tree path
         const parentPath = path.split('/').slice(0, -1).join('/');
         const parentNode = findNode(rootEntities, parentPath);
-        const parentType = parentNode?.type || 'component';
-        const entityType = `${parentType}s` as SovdResourceEntityType;
+        const entityType = NODE_TYPE_TO_RESOURCE[parentNode?.type?.toLowerCase() ?? ''] ?? 'components';
         const entityId = parentNode?.id || '';
 
         // Fetch the specific data item and transform to ComponentTopic
@@ -687,35 +716,6 @@ export async function fetchAllAppsDeduped(client: MedkitClient): Promise<Record<
 }
 
 /** Fallback: fetch entity details from API when not in tree */
-/**
- * Map a tree node's singular 'type' (e.g. "app", "function") to the plural
- * SOVD resources keyboard used in API routes (/apps, /functions, ...).
- */
-
-const NODE_TYPE_TO_RESOURCE: Record<string, SovdResourceEntityType> = {
-    area: 'areas',
-    subarea: 'areas',
-    component: 'components',
-    subcomponent: 'components',
-    app: 'apps',
-    function: 'functions',
-};
-
-/**
- * Find the parent Entity node for a resource path (/.../data/<id>, etc.) and
- * return its SOVD resource type.
- * Returns undefined if the parent isn't in the loaded tree or its type is unknown.
- */
-
-function resolveParentEntityType(path: string, rootEntities: EntityTreeNode[]): SovdResourceEntityType | undefined {
-    const match = path.match(/^(.*?)\/(data|operations|configurations|faults)(?:\/.*?)?$/);
-    if (!match) return undefined;
-    const parentPath = match[1]!;
-    const parentNode = findNode(rootEntities, parentPath);
-    if (!parentNode) return undefined;
-    return NODE_TYPE_TO_RESOURCE[parentNode.type?.toLowerCase()];
-}
-
 async function fetchEntityFromApi(
     path: string,
     client: MedkitClient,
@@ -726,10 +726,9 @@ async function fetchEntityFromApi(
 
     try {
         const parsed = parseTreePath(path);
-        // Prefer the parent tree node's real type over depth-based inference.
-        // which assumes a full area/component/app hierarchy and mis-labels
-        // apps as components in runtime_only (function/app) mode.
-
+        // Prefer the parent tree node's real type (entityTypeOverride) over
+        // depth-based inference, which assumes a full area/component/app
+        // hierarchy and mislabels apps as components in runtime_only mode.
         const entityType = entityTypeOverride ?? parsed.entityType;
 
         if (parsed.resource === 'data' && parsed.resourceId) {
@@ -1359,13 +1358,7 @@ export const useAppStore = create<AppState>()(
                 set({ isRefreshing: true });
 
                 try {
-                    const typeMap: Record<string, SovdResourceEntityType> = {
-                        area: 'areas',
-                        component: 'components',
-                        app: 'apps',
-                        function: 'functions',
-                    };
-                    const entityType = typeMap[selectedEntity.type];
+                    const entityType = NODE_TYPE_TO_RESOURCE[selectedEntity.type?.toLowerCase() ?? ''];
                     const entityId = selectedEntity.id;
 
                     if (!entityType) {


### PR DESCRIPTION
# Pull Request

## Summary

Follow-up polish on the parent entity-type resolution used by the topic data fallback (#77). No user-facing behavior change beyond dropping a latent invalid type cast.

- Export `resolveParentEntityType` and add unit tests covering the `runtime_only` function/app hierarchy (the scenario behind the topic data 400), `operations`/`configurations`/`faults` resource segments, and the not-in-tree and unknown-type fallbacks.
- Hoist `NODE_TYPE_TO_RESOURCE` and `resolveParentEntityType` next to `findNode` so the `/** Fallback: fetch entity details ... */` comment documents `fetchEntityFromApi` again.
- Replace the duplicate type maps in `handleTopicSelection` and `refreshSelectedEntity` with the shared `NODE_TYPE_TO_RESOURCE`, dropping the invalid `${type}s` cast for sub-area/sub-component node types.
- Fix a JSDoc typo and a split comment fragment.

---

## Issue

Link the related issue (required):

- closes #77

---

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- `npx vitest run` - 412 tests pass (16 files), including 9 new `resolveParentEntityType` cases in `store-helpers.test.ts`.
- `npm run typecheck`, `npm run lint`, `npm run format:check` - clean.
- `npm run build` - succeeds.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Docs were updated if behavior or public API changed
