### PR TITLE
Fix incorrect namespace rendering in node Overview page

### DIFF
--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -495,6 +495,15 @@ function handleAppSelection(ctx: SelectionContext): SelectionResult | null {
     if (node.type !== 'app') return null;
 
     const appData = node.data as App | undefined;
+    // Derive namespace from FQN if not explicitly set
+    // FQN like "/namespace/app_name" -> namespace: "namespace"
+
+    const fqn = appData?.fqn || node.name;
+    let namespace = appData?.namespace;
+    if (!namespace && fqn && fqn.includes('/')) {
+        const lastSlash = fqn.lastIndexOf('/');
+        namespace = lastSlash > 0 ? fqn.substring(0, lastSlash) : '/';
+    }
     return {
         selectedPath: path,
         expandedPaths: expandedPaths.includes(path) ? expandedPaths : [...expandedPaths, path],
@@ -503,9 +512,9 @@ function handleAppSelection(ctx: SelectionContext): SelectionResult | null {
             name: node.name,
             type: 'app',
             href: node.href,
-            fqn: appData?.fqn || node.name,
-            node_name: appData?.node_name,
-            namespace: appData?.namespace,
+            fqn,
+            node_name: appData?.node_name || (fqn.includes('/') ? fqn.substring(fqn.lastIndexOf('/') + 1) : node.name),
+            namespace,
             component_id: appData?.component_id,
         },
         isLoadingDetails: false,
@@ -1131,11 +1140,21 @@ export const useAppStore = create<AppState>()(
                                 .catch(() => null);
                             const hosts = hostsRes?.data ? unwrapItems<Record<string, unknown>>(hostsRes.data) : [];
 
-                            // Hosts response contains objects with {id, name, href}
+                            // Hosts response contains objects with {id, name, href, x-medkit: {ros2: {node: "/ns/name"}}}
                             loadedEntities = hosts.map((host: unknown) => {
-                                const hostObj = host as { id?: string; name?: string; href?: string };
+                                const hostObj = host as {
+                                    id?: string;
+                                    name?: string;
+                                    href?: string;
+                                    'x-medkit'?: { ros2?: { node?: string }; is_online?: boolean };
+                                };
                                 const hostId = hostObj.id || '';
                                 const hostName = hostObj.name || hostObj.id || '';
+                                const fqn = hostObj['x-medkit']?.ros2?.node || '';
+                                // Derive namespace from FQN: "/namespace/app_name" -> namespace: "namespace"
+                                const lastSlash = fqn.lastIndexOf('/');
+                                const namespace = lastSlash > 0 ? fqn.substring(0, lastSlash) : '/';
+                                const nodeName = lastSlash >= 0 ? fqn.substring(lastSlash + 1) : hostName;
                                 return {
                                     id: hostId,
                                     name: hostName,
@@ -1145,6 +1164,7 @@ export const useAppStore = create<AppState>()(
                                     hasChildren: false,
                                     isLoading: false,
                                     isExpanded: false,
+                                    data: { fqn, namespace, node_name: nodeName },
                                 };
                             });
                         }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -254,6 +254,27 @@ export function toTreeNode(entity: SovdEntity, parentPath: string = ''): EntityT
         hasChildren = entityType !== 'app';
     }
 
+    // Extract namespace/fqn from x-medkit.ros2.node for app entities
+    // This ensures the overview panel shows the correct namespace regardless
+    // of which tree branch (Component hosts, function hosts, or direct) loaded the app.
+
+    let data: Record<string, unknown> | undefined = undefined;
+    if (entityType === 'app') {
+        const xMedkit = entityAny['x-medkit'] as Record<string, unknown> | undefined;
+        const ros2 = xMedkit?.ros2 as Record<string, unknown> | undefined;
+        const fqn = (ros2?.node as string) || '';
+        if (fqn && fqn.includes('/')) {
+            const lastSlash = fqn.lastIndexOf('/');
+            const namespace = lastSlash > 0 ? fqn.substring(0, lastSlash) : '/';
+            const node_name = fqn.substring(lastSlash + 1);
+            data = {
+                fqn,
+                namespace,
+                node_name,
+            };
+        }
+    }
+
     return {
         ...entity,
         path,
@@ -261,6 +282,7 @@ export function toTreeNode(entity: SovdEntity, parentPath: string = ''): EntityT
         isLoading: false,
         isExpanded: false,
         hasChildren, // Controls whether expand button is shown
+        ...(data && { data }),
     };
 }
 


### PR DESCRIPTION
Display the actual ROS 2 node namespace in the Overview page instead of always rendering "/" for namespaced nodes.

This keeps the node details view consistent with the namespace grouping shown in the sidebar/entity tree.

# Pull Request

<!-- Thanks for contributing to ros2_medkit_web_ui! -->

## Summary

Fix incorrect namespace rendering in the node Overview page.

Previously, the node details view could show `/` as the namespace even when the node was actually running under a custom namespace. This happened because the app selection path was only using `appData.namespace` and `appData.fqn` when they were already populated, and the host data loaded from the backend was not always enriched with ROS 2 node namespace information.

This PR fixes the root cause in two places:

- In `handleAppSelection()`, the namespace is now derived from the FQN when `namespace` is missing.
- In `loadChildren()` for component hosts, the host data is now enriched with `x-medkit.ros2.node`, and the app node stores derived `fqn`, `namespace`, and `node_name` values.

As a result, the Overview page now displays the actual ROS 2 node namespace instead of always rendering `/`, and the node details view stays consistent with the namespace grouping shown in the sidebar/entity tree.

---

## Issue

Link the related issue (required):

- closes #79 

---

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

Tested locally in the provided VSCode devcontainer environment with ROS 2 Jazzy on Ubuntu using Google Chrome.

Verification steps:

1. Launch `ros2_medkit_gateway`
2. Run ROS 2 nodes with custom namespaces
3. Open `ros2_medkit_web_ui`
4. Confirm nodes are grouped correctly in the sidebar/entity tree
5. Click a namespaced node and verify the Overview page shows the correct namespace
6. Confirm the namespace is no longer rendered as `/` for namespaced nodes

Additionally verified with:

- `npm run lint`
- `npm run build`
- `npm run dev`


---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [ ] Docs were updated if behavior or public API changed
