### PR TITLE
ci: publish web UI image as multi-arch (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,13 +15,31 @@ env:
     IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-    build-and-push:
-        runs-on: ubuntu-latest
+    # Build each architecture on its OWN native runner, no QEMU emulation.
+    # arm64 runs on ubuntu-24.04-arm (free for public repos), which is why
+    # npm ci no longer segfaults the way it did under emulated cross-builds.
+    # On pull_request: build both arches to validate, do not push.
+    # On push/tag: push each arch by digest (no tag yet); the merge job tags.
+    build:
+        runs-on: ${{ matrix.runner }}
         permissions:
             contents: read
             packages: write
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - platform: linux/amd64
+                      runner: ubuntu-24.04
+                    - platform: linux/arm64
+                      runner: ubuntu-24.04-arm
 
         steps:
+            - name: Prepare platform pair
+              run: |
+                  platform=${{ matrix.platform }}
+                  echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
             - name: Checkout repository
               uses: actions/checkout@v4
 
@@ -30,6 +48,69 @@ jobs:
 
             - name: Log in to GitHub Container Registry
               if: github.event_name != 'pull_request'
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract metadata (labels)
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+            - name: Build and push by digest
+              id: build
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  platforms: ${{ matrix.platform }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  # Separate cache scope per arch so the two jobs do not evict each other.
+                  cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+                  cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+                  # push/tag: push by digest. pull_request: build only (validate, no push).
+                  outputs: ${{ github.event_name != 'pull_request' && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.IMAGE_NAME) || 'type=cacheonly' }}
+
+            - name: Export digest
+              if: github.event_name != 'pull_request'
+              run: |
+                  mkdir -p /tmp/digests
+                  digest="${{ steps.build.outputs.digest }}"
+                  touch "/tmp/digests/${digest#sha256:}"
+
+            - name: Upload digest
+              if: github.event_name != 'pull_request'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: digests-${{ env.PLATFORM_PAIR }}
+                  path: /tmp/digests/*
+                  if-no-files-found: error
+                  retention-days: 1
+
+    # Merge the per-arch digests into a single multi-arch manifest list and tag it.
+    # Skipped on pull_request (nothing was pushed to merge).
+    merge:
+        if: github.event_name != 'pull_request'
+        runs-on: ubuntu-latest
+        needs:
+            - build
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - name: Download digests
+              uses: actions/download-artifact@v4
+              with:
+                  path: /tmp/digests
+                  pattern: digests-*
+                  merge-multiple: true
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to GitHub Container Registry
               uses: docker/login-action@v3
               with:
                   registry: ${{ env.REGISTRY }}
@@ -53,14 +134,14 @@ jobs:
                       # sha for traceability
                       type=sha,prefix=sha-,format=short
 
-            - name: Build and push Docker image
-              uses: docker/build-push-action@v6
-              with:
-                  context: .
-                  push: ${{ github.event_name != 'pull_request' }}
-                  tags: ${{ steps.meta.outputs.tags }}
-                  labels: ${{ steps.meta.outputs.labels }}
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-                  # amd64 only - arm64 fails due to QEMU emulation issues with npm ci
-                  platforms: linux/amd64
+            - name: Create multi-arch manifest list
+              working-directory: /tmp/digests
+              run: |
+                  docker buildx imagetools create \
+                    $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+                    $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+            - name: Inspect manifest
+              run: |
+                  docker buildx imagetools inspect \
+                    ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
## Problem

`ghcr.io/selfpatch/ros2_medkit_web_ui:latest` is published for `linux/amd64` only. Pulling it on an arm64 host (Apple Silicon) fails with:

```
no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found
```

This breaks every Docker Compose demo that runs the web UI on an arm64 machine.

## Why it was amd64-only

arm64 was previously produced by cross-building under QEMU emulation, where `npm ci` and the Vite build segfault intermittently (`uncaught target signal 11`). The workflow was pinned to `platforms: linux/amd64` to avoid that flakiness.

## Fix

Build each architecture on its own native GitHub-hosted runner, no emulation:

- `linux/amd64` on `ubuntu-24.04`
- `linux/arm64` on `ubuntu-24.04-arm` (GA and free for public repos)

Each arch is pushed by digest, then a `merge` job assembles a single multi-arch manifest list with `docker buildx imagetools create`. The tag scheme (`latest`, semver, `sha-*`) and triggers are unchanged. Pull requests build both arches to validate, without pushing.

## Notes

- Job names change from `build-and-push` to `build` + `merge`; update any required status checks pinned to the old name.
- Per-arch GHA cache scopes prevent the two builds from evicting each other.
- Image consumers need no changes once the multi-arch manifest exists.
