### PR TITLE
Migrate to gateway 0.6.0 client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ros2_medkit_web_ui",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ros2_medkit_web_ui",
-            "version": "0.5.0",
+            "version": "0.6.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@radix-ui/react-collapsible": "^1.1.12",
@@ -15,7 +15,7 @@
                 "@radix-ui/react-slot": "^1.2.3",
                 "@radix-ui/react-switch": "^1.2.6",
                 "@radix-ui/react-tooltip": "^1.2.8",
-                "@selfpatch/ros2-medkit-client-ts": "^0.5.0",
+                "@selfpatch/ros2-medkit-client-ts": "^0.6.0",
                 "@tailwindcss/vite": "^4.1.14",
                 "class-variance-authority": "^0.7.1",
                 "clsx": "^2.1.1",
@@ -3249,9 +3249,9 @@
             ]
         },
         "node_modules/@selfpatch/ros2-medkit-client-ts": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@selfpatch/ros2-medkit-client-ts/-/ros2-medkit-client-ts-0.5.0.tgz",
-            "integrity": "sha512-q2G+8E3JEvtxm5cZ1nSIucySKCCVoojBin75r3QkBbyGk3Sn7ulCMrgTKFsSb6ST2C6A1q19ZOeWk0Ltf6zsVQ==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@selfpatch/ros2-medkit-client-ts/-/ros2-medkit-client-ts-0.6.0.tgz",
+            "integrity": "sha512-eeF3aFm4SJz+8zYBIukSZgG+9nQja2iJqIxfuKIjhBS6y04scpVSdCMMvYJJJBjoo+1KbgxWd017WwNgj7LHew==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "ros2_medkit_web_ui",
     "private": true,
-    "version": "0.5.0",
+    "version": "0.6.0",
     "type": "module",
     "description": "Simple web UI for browsing SOVD entity trees via discovery endpoints",
     "repository": {
@@ -37,7 +37,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.2.8",
-        "@selfpatch/ros2-medkit-client-ts": "^0.5.0",
+        "@selfpatch/ros2-medkit-client-ts": "^0.6.0",
         "@tailwindcss/vite": "^4.1.14",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/src/lib/api-dispatch.ts
+++ b/src/lib/api-dispatch.ts
@@ -549,33 +549,24 @@ export function getEntityLogs(
     if (params.severity) query.severity = params.severity;
     if (params.context) query.context = params.context;
 
-    // The 0.5.0 spec omits the /logs `severity`/`context` query params even though
-    // the gateway reads them at runtime; see selfpatch/ros2_medkit#416. Each call below
-    // passes the query with a suppressed type error until the client is regenerated from
-    // the fixed spec; the suppression is self-removing, as it errors once the params are
-    // typed.
     switch (entityType) {
         case 'apps':
             return client.GET('/apps/{app_id}/logs', {
-                // @ts-expect-error query params missing from the 0.5.0 spec (#416)
                 params: { path: { app_id: entityId }, query },
                 signal,
             });
         case 'components':
             return client.GET('/components/{component_id}/logs', {
-                // @ts-expect-error query params missing from the 0.5.0 spec (#416)
                 params: { path: { component_id: entityId }, query },
                 signal,
             });
         case 'areas':
             return client.GET('/areas/{area_id}/logs', {
-                // @ts-expect-error query params missing from the 0.5.0 spec (#416)
                 params: { path: { area_id: entityId }, query },
                 signal,
             });
         case 'functions':
             return client.GET('/functions/{function_id}/logs', {
-                // @ts-expect-error query params missing from the 0.5.0 spec (#416)
                 params: { path: { function_id: entityId }, query },
                 signal,
             });

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1894,12 +1894,8 @@ export const useAppStore = create<AppState>()(
                 try {
                     const { data: faultsData, error: faultsError } = await client.GET('/faults', {
                         params: {
-                            // The 0.5.0 spec omits the /faults `status` query param even though
-                            // the gateway reads it; see selfpatch/ros2_medkit#416. `status=all`
-                            // is required to include cleared/healed faults (no param returns only
-                            // active). Remove this cast once the client is regenerated from the
-                            // fixed spec.
-                            // @ts-expect-error query param missing from the 0.5.0 spec
+                            // `status=all` is required to include cleared/healed faults
+                            // (no param returns only active).
                             query: { status: 'all' },
                         },
                     });


### PR DESCRIPTION
## Summary

Pin the gateway 0.6.0 TypeScript client (`@selfpatch/ros2-medkit-client-ts@0.6.0`) and bump the app to 0.6.0. The 0.5.0 -> 0.6.0 change is additive (entity lifecycle status). The only code change is removing five now-stale `@ts-expect-error` directives for the `/logs` and `/faults` query params: the 0.6.0 client types those params, so the suppressions are obsolete (`tsc -b` flags them as unused). The `query` objects are passed identically - no runtime change.

---

## Issue

- closes #83

---

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

All gates pass in a worktree branched from `origin/main`:

- `npm run lint` (eslint) - clean
- `npm run typecheck` (`tsc --noEmit`) - clean
- `npm test -- --run` (vitest) - 414 passed
- `npm run build` (`tsc -b && vite build`) - succeeds

---

## Checklist

- [x] Breaking changes are clearly described (none - additive change only)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Docs were updated if behavior or public API changed (N/A - no API change)
