### PR TITLE
Add a Scripts tab for listing, running and writing diagnostic scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
             "version": "0.6.0",
             "license": "Apache-2.0",
             "dependencies": {
+                "@codemirror/lang-python": "^6.2.1",
+                "@codemirror/language": "^6.12.4",
+                "@codemirror/legacy-modes": "^6.5.3",
                 "@radix-ui/react-collapsible": "^1.1.12",
                 "@radix-ui/react-dialog": "^1.1.15",
                 "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -17,6 +20,7 @@
                 "@radix-ui/react-tooltip": "^1.2.8",
                 "@selfpatch/ros2-medkit-client-ts": "^0.6.0",
                 "@tailwindcss/vite": "^4.1.14",
+                "@uiw/react-codemirror": "^4.25.11",
                 "class-variance-authority": "^0.7.1",
                 "clsx": "^2.1.1",
                 "cmdk": "^1.1.1",
@@ -31,6 +35,7 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.36.0",
+                "@playwright/test": "^1.62.0",
                 "@tailwindcss/postcss": "^4.1.14",
                 "@testing-library/dom": "^10.4.1",
                 "@testing-library/jest-dom": "^6.9.1",
@@ -381,7 +386,6 @@
             "version": "7.28.6",
             "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
             "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -443,6 +447,121 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@codemirror/autocomplete": {
+            "version": "6.20.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+            "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.17.0",
+                "@lezer/common": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/commands": {
+            "version": "6.10.4",
+            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+            "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.7.0",
+                "@codemirror/view": "^6.27.0",
+                "@lezer/common": "^1.1.0"
+            }
+        },
+        "node_modules/@codemirror/lang-python": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+            "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/autocomplete": "^6.3.2",
+                "@codemirror/language": "^6.8.0",
+                "@codemirror/state": "^6.0.0",
+                "@lezer/common": "^1.2.1",
+                "@lezer/python": "^1.1.4"
+            }
+        },
+        "node_modules/@codemirror/language": {
+            "version": "6.12.4",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+            "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.23.0",
+                "@lezer/common": "^1.5.0",
+                "@lezer/highlight": "^1.0.0",
+                "@lezer/lr": "^1.0.0",
+                "style-mod": "^4.0.0"
+            }
+        },
+        "node_modules/@codemirror/legacy-modes": {
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/legacy-modes/-/legacy-modes-6.5.3.tgz",
+            "integrity": "sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0"
+            }
+        },
+        "node_modules/@codemirror/lint": {
+            "version": "6.9.7",
+            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+            "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.42.0",
+                "crelt": "^1.0.5"
+            }
+        },
+        "node_modules/@codemirror/search": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+            "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.37.0",
+                "crelt": "^1.0.5"
+            }
+        },
+        "node_modules/@codemirror/state": {
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+            "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+            "license": "MIT",
+            "dependencies": {
+                "@marijn/find-cluster-break": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/theme-one-dark": {
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+            "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.0.0",
+                "@lezer/highlight": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/view": {
+            "version": "6.43.7",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.7.tgz",
+            "integrity": "sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/state": "^6.7.0",
+                "crelt": "^1.0.6",
+                "style-mod": "^4.1.0",
+                "w3c-keyname": "^2.2.4"
             }
         },
         "node_modules/@csstools/color-helpers": {
@@ -1304,6 +1423,63 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@lezer/common": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+            "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+            "license": "MIT"
+        },
+        "node_modules/@lezer/highlight": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+            "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.3.0"
+            }
+        },
+        "node_modules/@lezer/lr": {
+            "version": "1.4.10",
+            "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+            "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.0.0"
+            }
+        },
+        "node_modules/@lezer/python": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.19.tgz",
+            "integrity": "sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.2.0",
+                "@lezer/highlight": "^1.0.0",
+                "@lezer/lr": "^1.0.0"
+            }
+        },
+        "node_modules/@marijn/find-cluster-break": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+            "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+            "license": "MIT"
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+            "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.62.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/@polka/url": {
@@ -4010,6 +4186,59 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@uiw/codemirror-extensions-basic-setup": {
+            "version": "4.25.11",
+            "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.11.tgz",
+            "integrity": "sha512-otyFa+n9IOYtEjaKOxPedHkj15fTPUF21wdR9pv0GpZPfuGl27cvmcv6+tognbRu9VvEcsHKE+ESoszeo3KfTw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/autocomplete": "^6.0.0",
+                "@codemirror/commands": "^6.0.0",
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/lint": "^6.0.0",
+                "@codemirror/search": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://jaywcjlove.github.io/#/sponsor"
+            },
+            "peerDependencies": {
+                "@codemirror/autocomplete": ">=6.0.0",
+                "@codemirror/commands": ">=6.0.0",
+                "@codemirror/language": ">=6.0.0",
+                "@codemirror/lint": ">=6.0.0",
+                "@codemirror/search": ">=6.0.0",
+                "@codemirror/state": ">=6.0.0",
+                "@codemirror/view": ">=6.0.0"
+            }
+        },
+        "node_modules/@uiw/react-codemirror": {
+            "version": "4.25.11",
+            "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.11.tgz",
+            "integrity": "sha512-DYVFAKLX+F/4JS9N/7xexh+TICrlncwkX9HKKInrP1bwO0tSfc3k0GB6oawTYhelVKh20cX3TuRx+NJSkVXuMw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.18.6",
+                "@codemirror/commands": "^6.1.0",
+                "@codemirror/state": "^6.1.1",
+                "@codemirror/theme-one-dark": "^6.0.0",
+                "@uiw/codemirror-extensions-basic-setup": "4.25.11",
+                "codemirror": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://jaywcjlove.github.io/#/sponsor"
+            },
+            "peerDependencies": {
+                "@babel/runtime": ">=7.11.0",
+                "@codemirror/state": ">=6.0.0",
+                "@codemirror/theme-one-dark": ">=6.0.0",
+                "@codemirror/view": ">=6.0.0",
+                "codemirror": ">=6.0.0",
+                "react": ">=17.0.0",
+                "react-dom": ">=17.0.0"
+            }
+        },
         "node_modules/@vitejs/plugin-react": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.1.tgz",
@@ -4596,6 +4825,21 @@
                 "react-dom": "^18 || ^19 || ^19.0.0-rc"
             }
         },
+        "node_modules/codemirror": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+            "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/autocomplete": "^6.0.0",
+                "@codemirror/commands": "^6.0.0",
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/lint": "^6.0.0",
+                "@codemirror/search": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@codemirror/view": "^6.0.0"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4645,6 +4889,12 @@
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/crelt": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+            "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
             "license": "MIT"
         },
         "node_modules/cross-spawn": {
@@ -6451,6 +6701,53 @@
                 "node": ">=0.10"
             }
         },
+        "node_modules/playwright": {
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+            "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.62.0"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.62.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+            "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/playwright/node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
         "node_modules/postcss": {
             "version": "8.5.6",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -7086,6 +7383,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/style-mod": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+            "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+            "license": "MIT"
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7578,6 +7881,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/w3c-keyname": {
+            "version": "2.2.8",
+            "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+            "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+            "license": "MIT"
         },
         "node_modules/w3c-xmlserializer": {
             "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
         "test": "vitest",
         "test:ui": "vitest --ui",
         "test:coverage": "vitest --coverage",
+        "test:e2e": "playwright test",
+        "test:e2e:ui": "playwright test --ui",
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "typecheck": "tsc --noEmit",
@@ -31,6 +33,9 @@
         ]
     },
     "dependencies": {
+        "@codemirror/lang-python": "^6.2.1",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/legacy-modes": "^6.5.3",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -39,6 +44,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@selfpatch/ros2-medkit-client-ts": "^0.6.0",
         "@tailwindcss/vite": "^4.1.14",
+        "@uiw/react-codemirror": "^4.25.11",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -53,6 +59,7 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@playwright/test": "^1.62.0",
         "@tailwindcss/postcss": "^4.1.14",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,20 +71,19 @@ function App() {
         }
     }, [selectedPath]);
 
-    // Auto-connect on mount if we have a stored URL (once only)
+    // Auto-connect on mount if we have a stored URL (once only). The ref guard
+    // alone survives React Strict Mode's mount-cleanup-remount cycle in dev;
+    // deferring the call via setTimeout previously let the Strict Mode cleanup
+    // cancel it before it ever fired, so connect() was never actually called.
     useEffect(() => {
         if (!serverUrl || isConnected || autoConnectAttempted.current) return;
         autoConnectAttempted.current = true;
 
-        const timeoutId = setTimeout(() => {
-            connect(serverUrl).then((success) => {
-                if (!success) {
-                    setShowConnectionDialog(true);
-                }
-            });
-        }, 0);
-
-        return () => clearTimeout(timeoutId);
+        connect(serverUrl).then((success) => {
+            if (!success) {
+                setShowConnectionDialog(true);
+            }
+        });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 

--- a/src/components/AppsPanel.test.tsx
+++ b/src/components/AppsPanel.test.tsx
@@ -1,0 +1,62 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppsPanel } from './AppsPanel';
+
+vi.mock('@/components/ScriptsPanel', () => ({
+    ScriptsPanel: ({ entityId, entityType }: { entityId: string; entityType: string }) => (
+        <div data-testid="scripts-panel">{`${entityType}:${entityId}`}</div>
+    ),
+}));
+
+const mockState = {
+    selectEntity: vi.fn(),
+    configurations: new Map<string, unknown[]>(),
+    fetchEntityData: vi.fn().mockResolvedValue([]),
+    fetchEntityOperations: vi.fn().mockResolvedValue([]),
+    listEntityFaults: vi.fn().mockResolvedValue({ items: [], count: 0 }),
+    scriptsSupported: false,
+};
+
+vi.mock('@/lib/store', () => ({
+    useAppStore: vi.fn((selector) => selector(mockState)),
+}));
+
+function renderAppsPanel(overrides: Partial<typeof mockState> = {}) {
+    Object.assign(mockState, { scriptsSupported: false }, overrides);
+    return render(<AppsPanel appId="talker" appName="Talker" path="/server/ecu/talker" />);
+}
+
+describe('AppsPanel scripts tab', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('hides the Scripts tab when the gateway does not report the capability', async () => {
+        renderAppsPanel({ scriptsSupported: false });
+        // Let the mount-time loadAppData effect settle before asserting, so its
+        // state updates don't land after the test body returns (act() warning).
+        await waitFor(() => {
+            expect(screen.queryByText(/Loading app resources/i)).not.toBeInTheDocument();
+        });
+        expect(screen.queryByRole('button', { name: /scripts/i })).not.toBeInTheDocument();
+    });
+
+    it('shows the Scripts tab and renders its content when the capability is reported', async () => {
+        renderAppsPanel({ scriptsSupported: true });
+        await userEvent.click(screen.getByRole('button', { name: /scripts/i }));
+        expect(screen.getByTestId('scripts-panel')).toHaveTextContent('apps:talker');
+    });
+});

--- a/src/components/AppsPanel.tsx
+++ b/src/components/AppsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
 import { AlertTriangle, Box, ChevronRight, Cpu, Database, FileCode, Network, Settings, Zap } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
@@ -9,6 +9,7 @@ import {
     RESOURCE_TABS,
     renderResourceTabContent,
     isResourceTabId,
+    SCRIPTS_TAB,
     type ResourceTabId,
 } from '@/components/ResourceTabs';
 import type { ComponentTopic, Operation, Fault } from '@/lib/types';
@@ -21,7 +22,7 @@ interface TabConfig {
     icon: typeof Database;
 }
 
-const APP_TABS: TabConfig[] = [{ id: 'overview', label: 'Overview', icon: Cpu }, ...RESOURCE_TABS];
+const BASE_APP_TABS: TabConfig[] = [{ id: 'overview', label: 'Overview', icon: Cpu }, ...RESOURCE_TABS];
 
 interface AppsPanelProps {
     appId: string;
@@ -50,15 +51,28 @@ export function AppsPanel({ appId, appName, fqn, nodeName, namespace, componentI
     const [faults, setFaults] = useState<Fault[]>([]);
     const [isLoading, setIsLoading] = useState(false);
 
-    const { selectEntity, configurations, fetchEntityData, fetchEntityOperations, listEntityFaults } = useAppStore(
-        useShallow((state) => ({
-            selectEntity: state.selectEntity,
-            configurations: state.configurations,
-            fetchEntityData: state.fetchEntityData,
-            fetchEntityOperations: state.fetchEntityOperations,
-            listEntityFaults: state.listEntityFaults,
-        }))
+    const { selectEntity, configurations, fetchEntityData, fetchEntityOperations, listEntityFaults, scriptsSupported } =
+        useAppStore(
+            useShallow((state) => ({
+                selectEntity: state.selectEntity,
+                configurations: state.configurations,
+                fetchEntityData: state.fetchEntityData,
+                fetchEntityOperations: state.fetchEntityOperations,
+                listEntityFaults: state.listEntityFaults,
+                scriptsSupported: state.scriptsSupported,
+            }))
+        );
+
+    const appTabs = useMemo(
+        () => (scriptsSupported ? [...BASE_APP_TABS, SCRIPTS_TAB] : BASE_APP_TABS),
+        [scriptsSupported]
     );
+
+    // Fall back to the default tab when the Scripts tab disappears (e.g. the
+    // gateway capability flips off) while it is the active tab.
+    useEffect(() => {
+        if (!scriptsSupported && activeTab === 'scripts') setActiveTab('overview');
+    }, [scriptsSupported, activeTab]);
 
     // Load app resources on mount (configurations are loaded by ConfigurationPanel)
     useEffect(() => {
@@ -141,7 +155,7 @@ export function AppsPanel({ appId, appName, fqn, nodeName, namespace, componentI
                 {/* Tab Navigation */}
                 <div className="px-6 pb-4">
                     <div className="flex gap-1 p-1 bg-muted rounded-lg overflow-x-auto">
-                        {APP_TABS.map((tab) => {
+                        {appTabs.map((tab) => {
                             const TabIcon = tab.icon;
                             const isActive = activeTab === tab.id;
                             let count = 0;

--- a/src/components/EntityDetailPanel.test.tsx
+++ b/src/components/EntityDetailPanel.test.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { EntityDetailPanel } from './EntityDetailPanel';
 
 // Mock heavy child components - we only care about the top-level routing
@@ -36,6 +36,11 @@ vi.mock('@/components/ResourceTabs', async () => {
         renderResourceTabContent: (tab: string) => <div data-testid={`tab-content-${tab}`} />,
     };
 });
+vi.mock('@/components/ScriptsPanel', () => ({
+    ScriptsPanel: ({ entityId, entityType }: { entityId: string; entityType: string }) => (
+        <div data-testid="scripts-panel">{`${entityType}:${entityId}`}</div>
+    ),
+}));
 
 const mockPrefetchResourceCounts = vi.fn();
 const mockFetchEntityData = vi.fn();
@@ -63,6 +68,7 @@ function setStore(overrides: Record<string, unknown>) {
         refreshSelectedEntity: mockRefreshSelectedEntity,
         prefetchResourceCounts: mockPrefetchResourceCounts,
         fetchEntityData: mockFetchEntityData,
+        scriptsSupported: false,
         ...overrides,
     };
 }
@@ -127,5 +133,51 @@ describe('EntityDetailPanel - nested entity types', () => {
         // not the "No detailed information available" fallback.
         expect(screen.getByTestId('areas-panel')).toBeInTheDocument();
         expect(screen.queryByText(/No detailed information available/i)).not.toBeInTheDocument();
+    });
+});
+
+describe('EntityDetailPanel - scripts tab gating (component view)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockPrefetchResourceCounts.mockResolvedValue({ data: 0, operations: 0, configurations: 0, faults: 0, logs: 0 });
+        mockFetchEntityData.mockResolvedValue([]);
+    });
+
+    it('hides the Scripts tab when the gateway does not report the capability', async () => {
+        setStore({
+            selectedPath: '/server/area1/component1',
+            selectedEntity: {
+                id: 'component1',
+                name: 'component1',
+                type: 'component',
+            },
+            scriptsSupported: false,
+        });
+
+        render(<EntityDetailPanel onConnectClick={() => {}} />);
+
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /Data/ })).toBeInTheDocument();
+        });
+        expect(screen.queryByRole('button', { name: /scripts/i })).not.toBeInTheDocument();
+    });
+
+    it('shows the Scripts tab and renders its content when the capability is reported', async () => {
+        setStore({
+            selectedPath: '/server/area1/component1',
+            selectedEntity: {
+                id: 'component1',
+                name: 'component1',
+                type: 'component',
+            },
+            scriptsSupported: true,
+        });
+
+        render(<EntityDetailPanel onConnectClick={() => {}} />);
+
+        const scriptsButton = await screen.findByRole('button', { name: /scripts/i });
+        fireEvent.click(scriptsButton);
+
+        expect(await screen.findByTestId('tab-content-scripts')).toBeInTheDocument();
     });
 });

--- a/src/components/EntityDetailPanel.tsx
+++ b/src/components/EntityDetailPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useShallow } from 'zustand/shallow';
 import {
     Copy,
@@ -24,7 +24,7 @@ import { EntityDetailSkeleton } from '@/components/EntityDetailSkeleton';
 import { DataPanel } from '@/components/DataPanel';
 import { ConfigurationPanel } from '@/components/ConfigurationPanel';
 import { OperationsPanel } from '@/components/OperationsPanel';
-import { RESOURCE_TABS, renderResourceTabContent, type ResourceTabId } from '@/components/ResourceTabs';
+import { RESOURCE_TABS, renderResourceTabContent, SCRIPTS_TAB, type ResourceTabId } from '@/components/ResourceTabs';
 import { AreasPanel } from '@/components/AreasPanel';
 import { AppsPanel } from '@/components/AppsPanel';
 import { FunctionsPanel } from '@/components/FunctionsPanel';
@@ -43,7 +43,7 @@ interface TabConfig {
     description?: string;
 }
 
-const COMPONENT_TABS: TabConfig[] = RESOURCE_TABS;
+const BASE_COMPONENT_TABS: TabConfig[] = RESOURCE_TABS;
 
 /**
  * Determine entity type for API calls based on entity type
@@ -376,6 +376,7 @@ export function EntityDetailPanel({ onConnectClick, viewMode = 'entity', onEntit
         configurations: 0,
         faults: 0,
         logs: 0,
+        scripts: 0,
     });
     // Store fetched topics data for the Data tab. `null` means "not yet loaded
     // for the current entity" so the Data tab can render a skeleton instead of
@@ -394,6 +395,7 @@ export function EntityDetailPanel({ onConnectClick, viewMode = 'entity', onEntit
         refreshSelectedEntity,
         prefetchResourceCounts,
         fetchEntityData,
+        scriptsSupported,
     } = useAppStore(
         useShallow((state: AppState) => ({
             selectedPath: state.selectedPath,
@@ -406,7 +408,13 @@ export function EntityDetailPanel({ onConnectClick, viewMode = 'entity', onEntit
             refreshSelectedEntity: state.refreshSelectedEntity,
             prefetchResourceCounts: state.prefetchResourceCounts,
             fetchEntityData: state.fetchEntityData,
+            scriptsSupported: state.scriptsSupported,
         }))
+    );
+
+    const componentTabs = useMemo(
+        () => (scriptsSupported ? [...BASE_COMPONENT_TABS, SCRIPTS_TAB] : BASE_COMPONENT_TABS),
+        [scriptsSupported]
     );
 
     // Notify parent when entity is selected
@@ -415,6 +423,12 @@ export function EntityDetailPanel({ onConnectClick, viewMode = 'entity', onEntit
             onEntitySelect();
         }
     }, [selectedPath, onEntitySelect]);
+
+    // Fall back to the default tab when the Scripts tab disappears (e.g. the
+    // gateway capability flips off) while it is the active tab.
+    useEffect(() => {
+        if (!scriptsSupported && activeTab === 'scripts') setActiveTab('data');
+    }, [scriptsSupported, activeTab]);
 
     // Reset the component-view resource tab to Data when the entity changes,
     // so switching between components doesn't show stale tab state.
@@ -430,6 +444,7 @@ export function EntityDetailPanel({ onConnectClick, viewMode = 'entity', onEntit
             configurations: 0,
             faults: 0,
             logs: 0,
+            scripts: 0,
         };
         // Guard against late results from a previous entity overwriting the
         // current entity's state. The cleanup aborts in-flight requests AND
@@ -482,7 +497,7 @@ export function EntityDetailPanel({ onConnectClick, viewMode = 'entity', onEntit
                 setTopicsData(fetchedData);
 
                 // Use the already-fetched data length instead of a separate request
-                setResourceCounts({ ...counts, data: fetchedData.length, logs: 0 });
+                setResourceCounts({ ...counts, data: fetchedData.length, logs: 0, scripts: 0 });
             } catch {
                 if (cancelled) return;
                 // On unexpected failure fall back to "loaded empty" so the UI
@@ -809,7 +824,7 @@ export function EntityDetailPanel({ onConnectClick, viewMode = 'entity', onEntit
                             {isComponent && (
                                 <div className="px-6 pb-4">
                                     <div className="flex gap-1 p-1 bg-muted rounded-lg">
-                                        {COMPONENT_TABS.map((tab) => {
+                                        {componentTabs.map((tab) => {
                                             const TabIcon = tab.icon;
                                             const isActive = activeTab === tab.id;
                                             const count = resourceCounts[tab.id];

--- a/src/components/EntityResourceTabs.tsx
+++ b/src/components/EntityResourceTabs.tsx
@@ -23,6 +23,7 @@ interface LoadedResources {
     configurations: boolean;
     faults: boolean;
     logs: boolean;
+    scripts: boolean;
 }
 
 /**
@@ -40,6 +41,7 @@ export function EntityResourceTabs({ entityId, entityType, basePath, onNavigate 
         configurations: false,
         faults: false,
         logs: false,
+        scripts: false,
     });
     const loadedTabsRef = useRef(loadedTabs);
     loadedTabsRef.current = loadedTabs;
@@ -141,6 +143,7 @@ export function EntityResourceTabs({ entityId, entityType, basePath, onNavigate 
             configurations: false,
             faults: false,
             logs: false,
+            scripts: false,
         };
         setActiveTab('data');
         setLoadedTabs(reset);

--- a/src/components/ResourceTabs.test.tsx
+++ b/src/components/ResourceTabs.test.tsx
@@ -1,0 +1,47 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { isResourceTabId, renderResourceTabContent, RESOURCE_TABS, SCRIPTS_TAB } from './ResourceTabs';
+
+vi.mock('@/components/ScriptsPanel', () => ({
+    ScriptsPanel: ({ entityId, entityType }: { entityId: string; entityType: string }) => (
+        <div data-testid="scripts-panel">{`${entityType}:${entityId}`}</div>
+    ),
+}));
+
+describe('isResourceTabId', () => {
+    it('accepts scripts', () => expect(isResourceTabId('scripts')).toBe(true));
+    it('rejects unknown ids', () => expect(isResourceTabId('nope')).toBe(false));
+});
+
+describe('RESOURCE_TABS', () => {
+    it('does not include scripts so areas and functions never show it', () => {
+        expect(RESOURCE_TABS.map((t) => t.id)).toEqual(['data', 'operations', 'configurations', 'faults', 'logs']);
+        expect(SCRIPTS_TAB.id).toBe('scripts');
+    });
+});
+
+describe('renderResourceTabContent for scripts', () => {
+    it.each(['apps', 'components'] as const)('renders the scripts panel for %s', (entityType) => {
+        render(<>{renderResourceTabContent('scripts', 'e1', entityType)}</>);
+        expect(screen.getByTestId('scripts-panel')).toHaveTextContent(`${entityType}:e1`);
+    });
+
+    it.each(['areas', 'functions'] as const)('renders nothing for %s', (entityType) => {
+        const { container } = render(<>{renderResourceTabContent('scripts', 'e1', entityType)}</>);
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/src/components/ResourceTabs.tsx
+++ b/src/components/ResourceTabs.tsx
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 import type { ReactNode } from 'react';
-import { AlertTriangle, Database, ScrollText, Settings, Zap } from 'lucide-react';
+import { AlertTriangle, Database, ScrollText, Settings, Terminal, Zap } from 'lucide-react';
 import { ConfigurationPanel } from '@/components/ConfigurationPanel';
 import { FaultsPanel } from '@/components/FaultsPanel';
 import { LogsPanel } from '@/components/LogsPanel';
 import { OperationsPanel } from '@/components/OperationsPanel';
+import { ScriptsPanel } from '@/components/ScriptsPanel';
 import type { SovdResourceEntityType } from '@/lib/types';
 
 /**
@@ -32,11 +33,11 @@ import type { SovdResourceEntityType } from '@/lib/types';
  * rendering stays per-panel because each entity type displays data
  * differently (apps: topics list, components: DataTabContent grid,
  * areas: aggregated grid). The helper `renderResourceTabContent` below
- * therefore only handles operations / configurations / faults / logs;
+ * therefore only handles operations / configurations / faults / logs / scripts;
  * callers are responsible for rendering their own data tab content.
  */
 
-export type ResourceTabId = 'data' | 'operations' | 'configurations' | 'faults' | 'logs';
+export type ResourceTabId = 'data' | 'operations' | 'configurations' | 'faults' | 'logs' | 'scripts';
 
 export interface ResourceTabConfig {
     id: ResourceTabId;
@@ -52,8 +53,22 @@ export const RESOURCE_TABS: ResourceTabConfig[] = [
     { id: 'logs', label: 'Logs', icon: ScrollText },
 ];
 
+/**
+ * Not part of RESOURCE_TABS: script routes exist for apps and components only,
+ * and the tab additionally requires the gateway to report capabilities.scripts.
+ * Panels append it themselves.
+ */
+export const SCRIPTS_TAB: ResourceTabConfig = { id: 'scripts', label: 'Scripts', icon: Terminal };
+
 export function isResourceTabId(id: string): id is ResourceTabId {
-    return id === 'data' || id === 'operations' || id === 'configurations' || id === 'faults' || id === 'logs';
+    return (
+        id === 'data' ||
+        id === 'operations' ||
+        id === 'configurations' ||
+        id === 'faults' ||
+        id === 'logs' ||
+        id === 'scripts'
+    );
 }
 
 /**
@@ -76,6 +91,10 @@ export function renderResourceTabContent(
             return <FaultsPanel entityId={entityId} entityType={entityType} />;
         case 'logs':
             return <LogsPanel entityId={entityId} entityType={entityType} />;
+        case 'scripts':
+            return entityType === 'apps' || entityType === 'components' ? (
+                <ScriptsPanel entityId={entityId} entityType={entityType} />
+            ) : null;
         case 'data':
             return null;
     }

--- a/src/components/ScriptEditor.tsx
+++ b/src/components/ScriptEditor.tsx
@@ -1,0 +1,92 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useEffect, useMemo, useState } from 'react';
+import CodeMirror, { EditorView } from '@uiw/react-codemirror';
+import type { Extension } from '@uiw/react-codemirror';
+import { python } from '@codemirror/lang-python';
+import { StreamLanguage } from '@codemirror/language';
+import { shell } from '@codemirror/legacy-modes/mode/shell';
+import { languageForFilename } from '@/lib/script-language';
+
+interface ScriptEditorProps {
+    value: string;
+    onChange: (value: string) => void;
+    filename: string;
+    /**
+     * Accessible name for the editor's contenteditable region. CodeMirror's
+     * content element is the one that actually carries the textbox role, so
+     * a wrapping <label htmlFor> does nothing for it - the name has to be
+     * applied here, through the contentAttributes facet below.
+     */
+    ariaLabel: string;
+    disabled?: boolean;
+}
+
+/**
+ * Reads the app's own dark-mode signal: a `dark` class on `document.documentElement`
+ * toggled by ThemeToggle. There is no exported hook for it, and this component
+ * stays self-contained rather than reach into ThemeToggle's internals, so it
+ * watches the class directly with a MutationObserver.
+ */
+function useIsDarkMode(): boolean {
+    const [isDark, setIsDark] = useState(() => document.documentElement.classList.contains('dark'));
+
+    useEffect(() => {
+        const root = document.documentElement;
+        const observer = new MutationObserver(() => {
+            setIsDark(root.classList.contains('dark'));
+        });
+        observer.observe(root, { attributes: true, attributeFilter: ['class'] });
+        return () => observer.disconnect();
+    }, []);
+
+    return isDark;
+}
+
+/**
+ * Thin wrapper around `@uiw/react-codemirror` used by the Write script mode of
+ * the upload dialog. Default export so it can be lazily imported and kept out
+ * of the main bundle.
+ */
+export default function ScriptEditor({ value, onChange, filename, ariaLabel, disabled }: ScriptEditorProps) {
+    const isDark = useIsDarkMode();
+
+    const language = languageForFilename(filename);
+    const extensions = useMemo<Extension[]>(() => {
+        const nameExtension = EditorView.contentAttributes.of({ 'aria-label': ariaLabel });
+        if (language === 'python') return [python(), nameExtension];
+        if (language === 'shell') return [StreamLanguage.define(shell), nameExtension];
+        return [nameExtension];
+    }, [language, ariaLabel]);
+
+    return (
+        <div data-testid="script-editor">
+            <CodeMirror
+                value={value}
+                onChange={onChange}
+                height="240px"
+                theme={isDark ? 'dark' : 'light'}
+                extensions={extensions}
+                editable={!disabled}
+                // Tab must move focus to the next dialog control, not indent -
+                // this is a modal, not a code-writing surface, and the usual
+                // Escape-then-Tab escape hatch closes the dialog instead since
+                // Escape isn't blocked here (see ScriptUploadDialog).
+                indentWithTab={false}
+                basicSetup={{ lineNumbers: true, autocompletion: false }}
+            />
+        </div>
+    );
+}

--- a/src/components/ScriptExecutionCard.test.tsx
+++ b/src/components/ScriptExecutionCard.test.tsx
@@ -1,0 +1,255 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ScriptExecutionCard } from './ScriptExecutionCard';
+import type { ScriptExecution, ScriptExecutionRecord } from '@/lib/types';
+
+// toast is used by the component but we don't need real notifications in tests.
+vi.mock('react-toastify', () => ({
+    toast: {
+        error: vi.fn(),
+    },
+}));
+
+const mockStopScriptExecution = vi.fn();
+const mockRemoveScriptExecution = vi.fn();
+const mockRefreshScriptExecution = vi.fn();
+
+vi.mock('@/lib/store', () => ({
+    useAppStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
+        selector({
+            stopScriptExecution: mockStopScriptExecution,
+            removeScriptExecution: mockRemoveScriptExecution,
+            refreshScriptExecution: mockRefreshScriptExecution,
+        })
+    ),
+}));
+
+function makeRecord(execution: Partial<ScriptExecution> & { id: string; status: string }): ScriptExecutionRecord {
+    return {
+        execution: execution as ScriptExecution,
+        scriptId: 'diag',
+        scriptName: 'Diagnostics',
+        entityType: 'components',
+        entityId: 'ecu',
+    };
+}
+
+describe('ScriptExecutionCard', () => {
+    beforeEach(() => {
+        mockStopScriptExecution.mockReset().mockResolvedValue(undefined);
+        mockRemoveScriptExecution.mockReset().mockResolvedValue(undefined);
+        mockRefreshScriptExecution.mockReset().mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders the raw status as the badge text', () => {
+        render(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'running' })} />);
+
+        expect(screen.getByTestId('execution-status')).toHaveTextContent('running');
+        expect(screen.getByTestId('execution-status')).toHaveAttribute('data-tone', 'neutral');
+    });
+
+    it('announces status changes via a live region', () => {
+        render(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'running' })} />);
+
+        // role="status" is an implicit polite live region: a screen-reader
+        // user who moved elsewhere still hears "completed" once it changes.
+        expect(screen.getByTestId('execution-status')).toHaveAttribute('role', 'status');
+    });
+
+    it('does not pulse the badge for a lost record even though its last known status was running', () => {
+        const record = { ...makeRecord({ id: 'exec_1', status: 'running' }), lost: true };
+        render(<ScriptExecutionCard record={record} />);
+
+        expect(screen.getByTestId('execution-status')).not.toHaveClass('animate-pulse');
+    });
+
+    it('sends action "stop" when Stop is clicked', async () => {
+        const user = userEvent.setup();
+        render(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'running' })} />);
+
+        await user.click(screen.getByRole('button', { name: 'Stop' }));
+
+        await waitFor(() => {
+            expect(mockStopScriptExecution).toHaveBeenCalledWith('components', 'ecu', 'diag', 'exec_1', 'stop');
+        });
+    });
+
+    it('sends action "forced_termination" when Force kill is clicked', async () => {
+        const user = userEvent.setup();
+        render(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'running' })} />);
+
+        await user.click(screen.getByRole('button', { name: 'Force kill' }));
+
+        await waitFor(() => {
+            expect(mockStopScriptExecution).toHaveBeenCalledWith(
+                'components',
+                'ecu',
+                'diag',
+                'exec_1',
+                'forced_termination'
+            );
+        });
+    });
+
+    it('hides Stop and Force kill for terminal statuses', () => {
+        render(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'completed' })} />);
+
+        expect(screen.queryByRole('button', { name: 'Stop' })).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Force kill' })).not.toBeInTheDocument();
+    });
+
+    it('shows Remove only for terminal statuses', () => {
+        const { rerender } = render(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'running' })} />);
+        expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+
+        rerender(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'completed' })} />);
+        expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+    });
+
+    it('renders the progress bar at 0 percent', () => {
+        render(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'running', progress: 0 })} />);
+
+        const bar = screen.getByRole('progressbar');
+        expect(bar).toHaveAttribute('aria-valuenow', '0');
+    });
+
+    it('hides the progress bar when progress is null', () => {
+        render(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'running', progress: null })} />);
+
+        expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    });
+
+    it('renders stdout-only output as plain text', () => {
+        render(
+            <ScriptExecutionCard
+                record={makeRecord({ id: 'exec_1', status: 'completed', parameters: { stdout: 'hi' } })}
+            />
+        );
+
+        expect(screen.getByText('hi')).toBeInTheDocument();
+    });
+
+    it('renders output as JSON when stdout appears with other keys', () => {
+        render(
+            <ScriptExecutionCard
+                record={makeRecord({
+                    id: 'exec_1',
+                    status: 'completed',
+                    parameters: { stdout: 'hi', exit_code: 0 },
+                })}
+            />
+        );
+
+        expect(screen.getByText(/"stdout"/)).toBeInTheDocument();
+        expect(screen.getByText(/"exit_code"/)).toBeInTheDocument();
+    });
+
+    it('renders no result area when parameters is null', () => {
+        const { container } = render(
+            <ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'completed', parameters: null })} />
+        );
+
+        expect(container.querySelector('pre')).not.toBeInTheDocument();
+    });
+
+    it('renders the error message and exit code for a failed execution', () => {
+        render(
+            <ScriptExecutionCard
+                record={makeRecord({
+                    id: 'exec_1',
+                    status: 'failed',
+                    error: { message: 'boom', exit_code: 3 },
+                })}
+            />
+        );
+
+        expect(screen.getByTestId('execution-status')).toHaveAttribute('data-tone', 'error');
+        expect(screen.getByText(/boom/)).toBeInTheDocument();
+        expect(screen.getByText(/exit code 3/)).toBeInTheDocument();
+    });
+
+    it('renders a terminated execution as stopped without an exit code', () => {
+        render(
+            <ScriptExecutionCard
+                record={makeRecord({
+                    id: 'exec_1',
+                    status: 'terminated',
+                    error: { message: 'Execution stopped by user' },
+                })}
+            />
+        );
+
+        expect(screen.getByTestId('execution-status')).toHaveAttribute('data-tone', 'stopped');
+        expect(screen.getByText(/Execution stopped by user/)).toBeInTheDocument();
+        expect(screen.queryByText(/exit code/i)).not.toBeInTheDocument();
+    });
+
+    it('renders an unknown status neutrally and still offers Refresh', () => {
+        render(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'weird' })} />);
+
+        expect(screen.getByTestId('execution-status')).toHaveAttribute('data-tone', 'neutral');
+        expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+    });
+
+    it('keeps showing the result of a lost record and still offers Remove', () => {
+        const record = {
+            ...makeRecord({ id: 'exec_1', status: 'running', parameters: { stdout: 'partial output' } }),
+            lost: true,
+        };
+        render(<ScriptExecutionCard record={record} />);
+
+        expect(screen.getByText('partial output')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Stop' })).not.toBeInTheDocument();
+    });
+
+    it('offers Refresh for a lost record', () => {
+        const record = { ...makeRecord({ id: 'exec_1', status: 'running' }), lost: true };
+        render(<ScriptExecutionCard record={record} />);
+
+        expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument();
+    });
+
+    it('schedules no timers of its own', () => {
+        vi.useFakeTimers();
+        render(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'running' })} />);
+
+        expect(vi.getTimerCount()).toBe(0);
+        vi.useRealTimers();
+    });
+
+    it('shows the gateway message when Stop is rejected with 409', async () => {
+        const { ScriptsApiError } = await import('@/lib/scripts');
+        mockStopScriptExecution.mockRejectedValueOnce(
+            new ScriptsApiError('Script is already running', 409, 'x-medkit-script-running')
+        );
+        const { toast } = await import('react-toastify');
+        const user = userEvent.setup();
+
+        render(<ScriptExecutionCard record={makeRecord({ id: 'exec_1', status: 'running' })} />);
+        await user.click(screen.getByRole('button', { name: 'Stop' }));
+
+        await waitFor(() => {
+            expect(toast.error).toHaveBeenCalledWith('Script is already running');
+        });
+    });
+});

--- a/src/components/ScriptExecutionCard.tsx
+++ b/src/components/ScriptExecutionCard.tsx
@@ -1,0 +1,202 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useState } from 'react';
+import { useShallow } from 'zustand/shallow';
+import { toast } from 'react-toastify';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useAppStore } from '@/lib/store';
+import { isActiveScriptStatus, scriptErrorMessage, scriptFailure, scriptOutput } from '@/lib/scripts';
+import type { ScriptExecutionRecord } from '@/lib/types';
+
+interface ScriptExecutionCardProps {
+    record: ScriptExecutionRecord;
+}
+
+type ExecutionTone = 'ok' | 'error' | 'stopped' | 'neutral';
+
+function toneForStatus(status: string): ExecutionTone {
+    if (status === 'completed') return 'ok';
+    if (status === 'failed') return 'error';
+    if (status === 'terminated') return 'stopped';
+    return 'neutral';
+}
+
+const TONE_BADGE_CLASSES: Record<ExecutionTone, string> = {
+    ok: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+    error: 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300',
+    stopped: 'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+    neutral: 'bg-muted text-muted-foreground',
+};
+
+const TONE_TEXT_CLASSES: Record<ExecutionTone, string> = {
+    ok: 'text-green-700 dark:text-green-400',
+    error: 'text-red-600 dark:text-red-400',
+    stopped: 'text-amber-700 dark:text-amber-400',
+    neutral: 'text-muted-foreground',
+};
+
+/** No in-flight button action. */
+type PendingAction = 'stop' | 'force' | 'remove' | 'refresh' | null;
+
+/**
+ * Displays one script execution: status badge, progress, result/error and the
+ * Stop / Force kill / Remove / Refresh controls. Schedules no timers itself -
+ * a single interval in the store polls every active execution, so this
+ * component only reacts to whatever record it is handed.
+ */
+export function ScriptExecutionCard({ record }: ScriptExecutionCardProps) {
+    const { execution, scriptId, entityType, entityId, lost } = record;
+    const status = execution.status;
+    // A record the gateway has evicted is never active for animation/control
+    // purposes, even if its last known status was a running one - otherwise
+    // the badge keeps pulsing "running" right next to the message saying the
+    // gateway no longer tracks it.
+    const active = isActiveScriptStatus(status) && !lost;
+    const tone = toneForStatus(status);
+    const progress = typeof execution.progress === 'number' ? execution.progress : null;
+    const output = scriptOutput(execution);
+    const failure = scriptFailure(execution);
+    const failureLabel = status === 'terminated' ? 'Stopped' : 'Error';
+
+    const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+
+    const { stopScriptExecution, removeScriptExecution, refreshScriptExecution } = useAppStore(
+        useShallow((state) => ({
+            stopScriptExecution: state.stopScriptExecution,
+            removeScriptExecution: state.removeScriptExecution,
+            refreshScriptExecution: state.refreshScriptExecution,
+        }))
+    );
+
+    const handleStop = async (action: string, which: PendingAction) => {
+        setPendingAction(which);
+        try {
+            await stopScriptExecution(entityType, entityId, scriptId, execution.id, action);
+        } catch (err) {
+            toast.error(scriptErrorMessage(err, 'Failed to stop the script'));
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    const handleRemove = async () => {
+        setPendingAction('remove');
+        try {
+            await removeScriptExecution(entityType, entityId, scriptId, execution.id);
+        } catch (err) {
+            toast.error(scriptErrorMessage(err, 'Failed to remove the execution'));
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    const handleRefresh = async () => {
+        setPendingAction('refresh');
+        try {
+            await refreshScriptExecution(entityType, entityId, scriptId, execution.id);
+        } catch (err) {
+            toast.error(scriptErrorMessage(err, 'Failed to refresh the execution'));
+        } finally {
+            setPendingAction(null);
+        }
+    };
+
+    const busy = pendingAction !== null;
+
+    return (
+        <Card>
+            <CardContent className="py-3 px-4 space-y-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span
+                        data-testid="execution-status"
+                        data-tone={tone}
+                        role="status"
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${TONE_BADGE_CLASSES[tone]} ${active ? 'animate-pulse' : ''}`}
+                    >
+                        {status}
+                    </span>
+                    {lost && (
+                        <span className="text-xs text-muted-foreground">
+                            The gateway no longer tracks this execution
+                        </span>
+                    )}
+                </div>
+
+                {progress !== null && (
+                    <div
+                        role="progressbar"
+                        aria-label={`Progress for execution ${execution.id}`}
+                        aria-valuenow={progress}
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                        className="w-full h-2 rounded-full bg-muted overflow-hidden"
+                    >
+                        <div className="h-full bg-blue-500 transition-all" style={{ width: `${progress}%` }} />
+                    </div>
+                )}
+
+                {output?.kind === 'stdout' && (
+                    <pre className="text-xs bg-muted rounded-md p-2 overflow-x-auto overflow-y-auto max-h-[200px] whitespace-pre-wrap">
+                        {output.text}
+                    </pre>
+                )}
+                {output?.kind === 'json' && (
+                    <pre className="text-xs bg-muted rounded-md p-2 overflow-x-auto overflow-y-auto max-h-[200px] whitespace-pre-wrap">
+                        {JSON.stringify(output.value, null, 2)}
+                    </pre>
+                )}
+
+                {failure && (
+                    <div className={`text-sm ${TONE_TEXT_CLASSES[tone]}`}>
+                        <span className="font-medium">{failureLabel}:</span> {failure.message}
+                        {failure.exitCode !== null && <span className="ml-1">exit code {failure.exitCode}</span>}
+                    </div>
+                )}
+
+                <div className="flex flex-wrap gap-2 pt-1">
+                    {active && (
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={busy}
+                            onClick={() => void handleStop('stop', 'stop')}
+                        >
+                            Stop
+                        </Button>
+                    )}
+                    {active && (
+                        <Button
+                            size="sm"
+                            variant="destructive"
+                            disabled={busy}
+                            onClick={() => void handleStop('forced_termination', 'force')}
+                        >
+                            Force kill
+                        </Button>
+                    )}
+                    {!active && (
+                        <Button size="sm" variant="outline" disabled={busy} onClick={() => void handleRemove()}>
+                            Remove
+                        </Button>
+                    )}
+                    <Button size="sm" variant="ghost" disabled={busy} onClick={() => void handleRefresh()}>
+                        Refresh
+                    </Button>
+                </div>
+            </CardContent>
+        </Card>
+    );
+}

--- a/src/components/ScriptRow.test.tsx
+++ b/src/components/ScriptRow.test.tsx
@@ -1,0 +1,455 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ScriptRow } from './ScriptRow';
+import type { ScriptExecution, ScriptExecutionRecord, ScriptMetadata } from '@/lib/types';
+
+// toast is used by the component but we don't need real notifications in tests.
+vi.mock('react-toastify', () => ({
+    toast: {
+        error: vi.fn(),
+    },
+}));
+
+const mockStartScriptExecutionAction = vi.fn();
+const mockDeleteScript = vi.fn();
+
+vi.mock('@/lib/store', () => ({
+    useAppStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
+        selector({
+            startScriptExecutionAction: mockStartScriptExecutionAction,
+            deleteScript: mockDeleteScript,
+        })
+    ),
+}));
+
+// ScriptRow only needs to know that ScriptExecutionCard renders somewhere - its
+// own behaviour (Stop/Force kill/Remove/Refresh) is covered by ScriptExecutionCard.test.tsx.
+vi.mock('@/components/ScriptExecutionCard', () => ({
+    ScriptExecutionCard: ({ record }: { record: ScriptExecutionRecord }) => (
+        <div data-testid={`execution-card-${record.execution.id}`}>{record.execution.status}</div>
+    ),
+}));
+
+function makeScript(overrides: Partial<ScriptMetadata> = {}): ScriptMetadata {
+    return {
+        id: 'diag',
+        name: 'Diagnostics',
+        description: 'Runs full diagnostics',
+        managed: false,
+        proximity_proof_required: false,
+        parameters_schema: null,
+        ...overrides,
+    };
+}
+
+function makeRecord(execution: Partial<ScriptExecution> & { id: string; status: string }): ScriptExecutionRecord {
+    return {
+        execution: execution as ScriptExecution,
+        scriptId: 'diag',
+        scriptName: 'Diagnostics',
+        entityType: 'components',
+        entityId: 'ecu',
+    };
+}
+
+/**
+ * The expander button's accessible name is computed from its content (script
+ * name, "managed" badge, description), not overridden with aria-label, so it
+ * is no longer just the script name verbatim. Testing Library's `name` option
+ * matches a string exactly but a RegExp only needs to match somewhere in the
+ * name - anchored to the start here since the script name is always first.
+ */
+function expanderName(name: string): RegExp {
+    return new RegExp(`^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`);
+}
+
+async function expandRow(name: string) {
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: expanderName(name) }));
+    return user;
+}
+
+describe('ScriptRow', () => {
+    beforeEach(() => {
+        mockStartScriptExecutionAction.mockReset().mockResolvedValue(undefined);
+        mockDeleteScript.mockReset().mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders the script name and description', () => {
+        render(
+            <ScriptRow
+                script={makeScript()}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        expect(screen.getByRole('button', { name: expanderName('Diagnostics') })).toBeInTheDocument();
+        expect(screen.getByText('Runs full diagnostics')).toBeInTheDocument();
+    });
+
+    it('exposes managed status in the accessible name and the description via aria-describedby', () => {
+        render(
+            <ScriptRow
+                script={makeScript({ managed: true })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        // The name stays short (script name + "managed") rather than folding
+        // in the free-text description, which would risk colliding with
+        // other buttons' names (e.g. a description containing "Runs" would
+        // otherwise substring-match a "Run" button) - the description is
+        // still reachable through aria-describedby instead.
+        const expander = screen.getByRole('button', { name: 'Diagnostics managed' });
+        const describedBy = expander.getAttribute('aria-describedby');
+        expect(describedBy).toBeTruthy();
+        expect(document.getElementById(describedBy as string)).toHaveTextContent('Runs full diagnostics');
+    });
+
+    it('renders one form field per schema property and sends the entered values as parameters', async () => {
+        const script = makeScript({
+            parameters_schema: { type: 'object', properties: { verbose: { type: 'boolean' } } },
+        });
+        render(
+            <ScriptRow script={script} entityId="ecu" entityType="components" executions={[]} onDeleted={vi.fn()} />
+        );
+
+        const user = await expandRow('Diagnostics');
+        expect(screen.getByText('verbose')).toBeInTheDocument();
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).not.toBeChecked();
+
+        await user.click(checkbox);
+        await user.click(screen.getByRole('button', { name: 'Run' }));
+
+        await waitFor(() => {
+            expect(mockStartScriptExecutionAction).toHaveBeenCalledWith(
+                'components',
+                'ecu',
+                expect.objectContaining({ id: 'diag' }),
+                { execution_type: 'now', parameters: { verbose: true } }
+            );
+        });
+    });
+
+    it('falls back to the raw JSON textarea when the script has no parameters schema', async () => {
+        render(
+            <ScriptRow
+                script={makeScript({ parameters_schema: null })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        await expandRow('Diagnostics');
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+        expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    });
+
+    it('falls back to the raw JSON textarea for a schema without properties', async () => {
+        // Conversion returns {type: 'object'} unchanged - an object without fields
+        // shaped as SchemaFieldType. Feeding it to SchemaForm would throw inside
+        // getSchemaDefaults, so this must take the textarea path instead.
+        render(
+            <ScriptRow
+                script={makeScript({ parameters_schema: { type: 'object' } })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        await expandRow('Diagnostics');
+        expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+
+    it('omits parameters when the raw JSON textarea is empty', async () => {
+        render(
+            <ScriptRow
+                script={makeScript({ parameters_schema: null })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        const user = await expandRow('Diagnostics');
+        await user.click(screen.getByRole('button', { name: 'Run' }));
+
+        await waitFor(() => {
+            expect(mockStartScriptExecutionAction).toHaveBeenCalledWith(
+                'components',
+                'ecu',
+                expect.objectContaining({ id: 'diag' }),
+                { execution_type: 'now' }
+            );
+        });
+    });
+
+    it('blocks Run and shows an inline error for invalid JSON', async () => {
+        render(
+            <ScriptRow
+                script={makeScript({ parameters_schema: null })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        const user = await expandRow('Diagnostics');
+        // userEvent.type() parses "{"/"}" as special-key syntax, so set the raw
+        // invalid text directly instead.
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: '{not valid json' } });
+        await user.click(screen.getByRole('button', { name: 'Run' }));
+
+        expect(await screen.findByText(/Invalid JSON/i)).toBeInTheDocument();
+        expect(mockStartScriptExecutionAction).not.toHaveBeenCalled();
+    });
+
+    it('keeps typed values while the row re-renders', async () => {
+        const script = makeScript({
+            parameters_schema: { type: 'object', properties: { verbose: { type: 'boolean' } } },
+        });
+        const { rerender } = render(
+            <ScriptRow script={script} entityId="ecu" entityType="components" executions={[]} onDeleted={vi.fn()} />
+        );
+
+        const user = await expandRow('Diagnostics');
+        await user.click(screen.getByRole('checkbox'));
+        expect(screen.getByRole('checkbox')).toBeChecked();
+
+        // Simulate the store's once-per-second poll writing a new executions array
+        // while the user is mid-edit. The script reference itself is unchanged.
+        rerender(
+            <ScriptRow
+                script={script}
+                entityId="ecu"
+                entityType="components"
+                executions={[makeRecord({ id: 'exec_1', status: 'running' })]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        expect(screen.getByRole('checkbox')).toBeChecked();
+    });
+
+    it('sends proximity_response only when the field is filled', async () => {
+        render(
+            <ScriptRow
+                script={makeScript({ parameters_schema: null, proximity_proof_required: true })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        const user = await expandRow('Diagnostics');
+        await user.type(screen.getByLabelText('Proximity response'), 'abc123');
+        await user.click(screen.getByRole('button', { name: 'Run' }));
+
+        await waitFor(() => {
+            expect(mockStartScriptExecutionAction).toHaveBeenCalledWith(
+                'components',
+                'ecu',
+                expect.objectContaining({ id: 'diag' }),
+                { execution_type: 'now', proximity_response: 'abc123' }
+            );
+        });
+    });
+
+    it('does not render the proximity field when the script does not require it', async () => {
+        render(
+            <ScriptRow
+                script={makeScript({ proximity_proof_required: false })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        await expandRow('Diagnostics');
+        expect(screen.queryByLabelText('Proximity response')).not.toBeInTheDocument();
+    });
+
+    it('always sends execution_type "now"', async () => {
+        render(
+            <ScriptRow
+                script={makeScript({ parameters_schema: null })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        const user = await expandRow('Diagnostics');
+        await user.click(screen.getByRole('button', { name: 'Run' }));
+
+        await waitFor(() => {
+            const [, , , request] = mockStartScriptExecutionAction.mock.calls[0] as [
+                unknown,
+                unknown,
+                unknown,
+                { execution_type: string },
+            ];
+            expect(request.execution_type).toBe('now');
+        });
+    });
+
+    it('hides Delete for managed scripts', async () => {
+        const { rerender } = render(
+            <ScriptRow
+                script={makeScript({ managed: false })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        await expandRow('Diagnostics');
+        expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+
+        rerender(
+            <ScriptRow
+                script={makeScript({ managed: true })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+        expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    });
+
+    it('calls deleteScript and onDeleted when Delete succeeds', async () => {
+        const onDeleted = vi.fn();
+        render(
+            <ScriptRow
+                script={makeScript()}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={onDeleted}
+            />
+        );
+
+        const user = await expandRow('Diagnostics');
+        await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+        await waitFor(() => {
+            expect(mockDeleteScript).toHaveBeenCalledWith('components', 'ecu', 'diag');
+            expect(onDeleted).toHaveBeenCalled();
+        });
+    });
+
+    it('disables Run while the request is in flight', async () => {
+        let resolveStart: (() => void) | undefined;
+        mockStartScriptExecutionAction.mockImplementation(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveStart = resolve;
+                })
+        );
+
+        render(
+            <ScriptRow
+                script={makeScript({ parameters_schema: null })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        const user = await expandRow('Diagnostics');
+        const runButton = screen.getByRole('button', { name: 'Run' });
+        await user.click(runButton);
+
+        await waitFor(() => {
+            expect(runButton).toBeDisabled();
+        });
+
+        resolveStart?.();
+        await waitFor(() => {
+            expect(runButton).not.toBeDisabled();
+        });
+    });
+
+    it('keeps the execution card mounted after the row is collapsed', async () => {
+        render(
+            <ScriptRow
+                script={makeScript()}
+                entityId="ecu"
+                entityType="components"
+                executions={[makeRecord({ id: 'exec_1', status: 'running' })]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        expect(screen.getByTestId('execution-card-exec_1')).toBeInTheDocument();
+
+        const user = await expandRow('Diagnostics');
+        expect(screen.getByTestId('execution-card-exec_1')).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: expanderName('Diagnostics') }));
+        expect(screen.getByTestId('execution-card-exec_1')).toBeInTheDocument();
+    });
+
+    it('shows the gateway message when Run is rejected with 429', async () => {
+        const { ScriptsApiError } = await import('@/lib/scripts');
+        mockStartScriptExecutionAction.mockRejectedValueOnce(
+            new ScriptsApiError('Too many concurrent scripts', 429, 'x-medkit-concurrency-limit')
+        );
+        const { toast } = await import('react-toastify');
+
+        render(
+            <ScriptRow
+                script={makeScript({ parameters_schema: null })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        const user = await expandRow('Diagnostics');
+        await user.click(screen.getByRole('button', { name: 'Run' }));
+
+        await waitFor(() => {
+            expect(toast.error).toHaveBeenCalledWith('Too many concurrent scripts');
+        });
+    });
+});

--- a/src/components/ScriptRow.test.tsx
+++ b/src/components/ScriptRow.test.tsx
@@ -236,6 +236,30 @@ describe('ScriptRow', () => {
         expect(mockStartScriptExecutionAction).not.toHaveBeenCalled();
     });
 
+    it.each([
+        ['[1,2]', 'an array'],
+        ['"hello"', 'a string'],
+        ['42', 'a number'],
+        ['null', 'null'],
+    ])('blocks Run and shows an inline error when the JSON parses to %s (%s)', async (raw) => {
+        render(
+            <ScriptRow
+                script={makeScript({ parameters_schema: null })}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={vi.fn()}
+            />
+        );
+
+        const user = await expandRow('Diagnostics');
+        fireEvent.change(screen.getByRole('textbox'), { target: { value: raw } });
+        await user.click(screen.getByRole('button', { name: 'Run' }));
+
+        expect(await screen.findByText(/must be a JSON object/i)).toBeInTheDocument();
+        expect(mockStartScriptExecutionAction).not.toHaveBeenCalled();
+    });
+
     it('keeps typed values while the row re-renders', async () => {
         const script = makeScript({
             parameters_schema: { type: 'object', properties: { verbose: { type: 'boolean' } } },
@@ -354,7 +378,8 @@ describe('ScriptRow', () => {
         expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
     });
 
-    it('calls deleteScript and onDeleted when Delete succeeds', async () => {
+    it('calls deleteScript and onDeleted when Delete succeeds and the confirmation is accepted', async () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(true);
         const onDeleted = vi.fn();
         render(
             <ScriptRow
@@ -370,9 +395,31 @@ describe('ScriptRow', () => {
         await user.click(screen.getByRole('button', { name: 'Delete' }));
 
         await waitFor(() => {
+            expect(window.confirm).toHaveBeenCalled();
             expect(mockDeleteScript).toHaveBeenCalledWith('components', 'ecu', 'diag');
             expect(onDeleted).toHaveBeenCalled();
         });
+    });
+
+    it('does not call deleteScript when the confirmation is declined', async () => {
+        vi.spyOn(window, 'confirm').mockReturnValue(false);
+        const onDeleted = vi.fn();
+        render(
+            <ScriptRow
+                script={makeScript()}
+                entityId="ecu"
+                entityType="components"
+                executions={[]}
+                onDeleted={onDeleted}
+            />
+        );
+
+        const user = await expandRow('Diagnostics');
+        await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+        expect(window.confirm).toHaveBeenCalled();
+        expect(mockDeleteScript).not.toHaveBeenCalled();
+        expect(onDeleted).not.toHaveBeenCalled();
     });
 
     it('disables Run while the request is in flight', async () => {

--- a/src/components/ScriptRow.tsx
+++ b/src/components/ScriptRow.tsx
@@ -22,7 +22,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { useAppStore } from '@/lib/store';
-import { scriptErrorMessage } from '@/lib/scripts';
+import { isPlainJsonObject, scriptErrorMessage } from '@/lib/scripts';
 import { convertJsonSchemaToTopicSchema, getSchemaDefaults } from '@/lib/schema-utils';
 import { SchemaForm } from '@/components/SchemaFormField';
 import { ScriptExecutionCard } from '@/components/ScriptExecutionCard';
@@ -104,12 +104,22 @@ export function ScriptRow({ script, entityId, entityType, executions, onDeleted 
         } else {
             const trimmed = jsonText.trim();
             if (trimmed) {
+                let parsed: unknown;
                 try {
-                    parameters = JSON.parse(trimmed) as Record<string, unknown>;
+                    parsed = JSON.parse(trimmed);
                 } catch (err) {
                     setJsonError(err instanceof Error ? err.message : 'Invalid JSON');
                     return;
                 }
+                // JSON.parse happily accepts an array, a string, a number or
+                // null - all valid JSON, none of them usable as parameters.
+                // Catching that here, rather than letting the gateway 400 on
+                // it, keeps the failure on this field's existing inline path.
+                if (!isPlainJsonObject(parsed)) {
+                    setJsonError('Parameters must be a JSON object, e.g. {"key": "value"}');
+                    return;
+                }
+                parameters = parsed;
             }
             setJsonError(null);
         }
@@ -132,6 +142,12 @@ export function ScriptRow({ script, entityId, entityType, executions, onDeleted 
     };
 
     const handleDelete = async () => {
+        // Deleting a script from the robot is irreversible and one click
+        // away from Run in the same row - matches the confirmation already
+        // required for the other irreversible delete in this codebase
+        // (UpdatesDashboard).
+        if (!window.confirm(`Delete script "${script.name}"? This cannot be undone.`)) return;
+
         setIsDeleting(true);
         try {
             await deleteScript(entityType, entityId, script.id);

--- a/src/components/ScriptRow.tsx
+++ b/src/components/ScriptRow.tsx
@@ -1,0 +1,274 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useEffect, useMemo, useState } from 'react';
+import { useShallow } from 'zustand/shallow';
+import { toast } from 'react-toastify';
+import { ChevronDown, ChevronUp, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { useAppStore } from '@/lib/store';
+import { scriptErrorMessage } from '@/lib/scripts';
+import { convertJsonSchemaToTopicSchema, getSchemaDefaults } from '@/lib/schema-utils';
+import { SchemaForm } from '@/components/SchemaFormField';
+import { ScriptExecutionCard } from '@/components/ScriptExecutionCard';
+import type {
+    ScriptEntityType,
+    ScriptExecutionRecord,
+    ScriptMetadata,
+    StartScriptExecutionRequest,
+    TopicSchema,
+} from '@/lib/types';
+
+interface ScriptRowProps {
+    script: ScriptMetadata;
+    entityId: string;
+    entityType: ScriptEntityType;
+    /** Executions of this script only, newest first. */
+    executions: ScriptExecutionRecord[];
+    onDeleted: () => void;
+}
+
+/**
+ * Only a schema whose every entry looks like a SchemaFieldType can drive the
+ * form. `convertJsonSchemaToTopicSchema` passes an unrecognised schema through
+ * unchanged, and feeding e.g. {type: 'object'} to SchemaForm throws inside
+ * getSchemaDefaults. Anything else falls back to the raw JSON editor.
+ */
+function schemaLooksLikeForm(schema: TopicSchema | undefined): schema is TopicSchema {
+    return (
+        !!schema &&
+        Object.values(schema).length > 0 &&
+        Object.values(schema).every((field) => typeof field === 'object' && field !== null && 'type' in field)
+    );
+}
+
+/**
+ * Expandable row for a single script: metadata, the parameter form (or raw
+ * JSON editor as fallback), Run and Delete controls, and the execution cards
+ * for this script's runs.
+ */
+export function ScriptRow({ script, entityId, entityType, executions, onDeleted }: ScriptRowProps) {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const [isStarting, setIsStarting] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
+    const [jsonText, setJsonText] = useState('');
+    const [jsonError, setJsonError] = useState<string | null>(null);
+    const [formValues, setFormValues] = useState<Record<string, unknown>>({});
+    const [proximityResponse, setProximityResponse] = useState('');
+
+    const { startScriptExecutionAction, deleteScript } = useAppStore(
+        useShallow((state) => ({
+            startScriptExecutionAction: state.startScriptExecutionAction,
+            deleteScript: state.deleteScript,
+        }))
+    );
+
+    /**
+     * The conversion MUST be memoised on the schema reference: the helper
+     * builds a fresh object on every call and the effect below that seeds the
+     * form's defaults is keyed on that reference. Without the memo the store's
+     * once-per-second polling loop would wipe whatever the user is typing.
+     */
+    const formSchema = useMemo(
+        () => (script.parameters_schema ? convertJsonSchemaToTopicSchema(script.parameters_schema) : undefined),
+        [script.parameters_schema]
+    );
+
+    const usesForm = schemaLooksLikeForm(formSchema);
+
+    useEffect(() => {
+        if (usesForm && formSchema) {
+            setFormValues(getSchemaDefaults(formSchema));
+        }
+    }, [formSchema, usesForm]);
+
+    const handleRun = async () => {
+        let parameters: Record<string, unknown> | undefined;
+        if (usesForm) {
+            parameters = formValues;
+        } else {
+            const trimmed = jsonText.trim();
+            if (trimmed) {
+                try {
+                    parameters = JSON.parse(trimmed) as Record<string, unknown>;
+                } catch (err) {
+                    setJsonError(err instanceof Error ? err.message : 'Invalid JSON');
+                    return;
+                }
+            }
+            setJsonError(null);
+        }
+
+        const trimmedProximity = proximityResponse.trim();
+        const request: StartScriptExecutionRequest = {
+            execution_type: 'now',
+            ...(parameters !== undefined ? { parameters } : {}),
+            ...(trimmedProximity ? { proximity_response: trimmedProximity } : {}),
+        };
+
+        setIsStarting(true);
+        try {
+            await startScriptExecutionAction(entityType, entityId, script, request);
+        } catch (err) {
+            toast.error(scriptErrorMessage(err, 'Failed to start the script'));
+        } finally {
+            setIsStarting(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        setIsDeleting(true);
+        try {
+            await deleteScript(entityType, entityId, script.id);
+            onDeleted();
+        } catch (err) {
+            toast.error(scriptErrorMessage(err, 'Failed to delete the script'));
+        } finally {
+            setIsDeleting(false);
+        }
+    };
+
+    const descriptionId = `script-description-${script.id}`;
+
+    return (
+        <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+            <div className="rounded-lg border bg-card">
+                <CollapsibleTrigger asChild>
+                    {/*
+                     * The accessible name stays short and controlled-vocabulary
+                     * (script name, plus "managed" when it applies) instead of
+                     * hiding that status entirely as a bare aria-label={script.name}
+                     * used to. The free-text description is deliberately kept
+                     * out of the name itself - it is attached via aria-describedby
+                     * instead - because concatenating arbitrary manifest prose
+                     * into the name risks colliding with short action-button
+                     * names elsewhere on the page (e.g. a description containing
+                     * "Runs" would otherwise substring-match a "Run" button).
+                     */}
+                    <button
+                        type="button"
+                        aria-label={script.managed === true ? `${script.name} managed` : script.name}
+                        aria-describedby={script.description ? descriptionId : undefined}
+                        className="w-full flex items-center gap-3 p-3 text-left cursor-pointer hover:bg-accent/30 transition-colors"
+                    >
+                        <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                                <span className="font-medium text-sm truncate">{script.name}</span>
+                                {script.managed === true && (
+                                    <Badge variant="outline" className="shrink-0 text-xs">
+                                        managed
+                                    </Badge>
+                                )}
+                            </div>
+                            {script.description && (
+                                <p id={descriptionId} className="text-xs text-muted-foreground truncate">
+                                    {script.description}
+                                </p>
+                            )}
+                        </div>
+                        {isExpanded ? (
+                            <ChevronUp className="w-4 h-4 text-muted-foreground shrink-0" />
+                        ) : (
+                            <ChevronDown className="w-4 h-4 text-muted-foreground shrink-0" />
+                        )}
+                    </button>
+                </CollapsibleTrigger>
+
+                <CollapsibleContent>
+                    <div className="px-3 pb-3 space-y-3 border-t pt-3">
+                        <p className="text-xs text-muted-foreground">
+                            Parameters are passed to the script as JSON on stdin unless the manifest entry declares
+                            args.
+                        </p>
+
+                        {usesForm && formSchema ? (
+                            <div className="bg-muted/30 p-3 rounded-md">
+                                <SchemaForm schema={formSchema} value={formValues} onChange={setFormValues} />
+                            </div>
+                        ) : (
+                            <div className="space-y-2">
+                                <Textarea
+                                    value={jsonText}
+                                    onChange={(e) => {
+                                        setJsonText(e.target.value);
+                                        setJsonError(null);
+                                    }}
+                                    placeholder="{}"
+                                    className={`font-mono text-sm min-h-[80px] ${jsonError ? 'border-destructive' : ''}`}
+                                />
+                                {jsonError && (
+                                    <div className="flex items-center gap-2 text-xs text-destructive">
+                                        <AlertCircle className="w-3 h-3" />
+                                        Invalid JSON: {jsonError}
+                                    </div>
+                                )}
+                            </div>
+                        )}
+
+                        {/*
+                         * The gateway's built-in backend always reports proximity_proof_required
+                         * as false; this field only matters for plugin backends that require a
+                         * proximity proof before starting the script.
+                         */}
+                        {script.proximity_proof_required === true && (
+                            <div className="space-y-1">
+                                <label
+                                    htmlFor={`proximity-${script.id}`}
+                                    className="text-xs font-medium text-muted-foreground"
+                                >
+                                    Proximity response
+                                </label>
+                                <Input
+                                    id={`proximity-${script.id}`}
+                                    value={proximityResponse}
+                                    onChange={(e) => setProximityResponse(e.target.value)}
+                                    placeholder="Proximity proof response"
+                                />
+                            </div>
+                        )}
+
+                        <div className="flex flex-wrap gap-2">
+                            <Button variant="default" size="sm" disabled={isStarting} onClick={() => void handleRun()}>
+                                Run
+                            </Button>
+                            {script.managed !== true && (
+                                <Button
+                                    variant="destructive"
+                                    size="sm"
+                                    disabled={isDeleting}
+                                    onClick={() => void handleDelete()}
+                                >
+                                    Delete
+                                </Button>
+                            )}
+                        </div>
+                    </div>
+                </CollapsibleContent>
+
+                {/* Rendered outside CollapsibleContent so collapsing the row does not unmount them. */}
+                {executions.length > 0 && (
+                    <div className="px-3 pb-3 space-y-2">
+                        {executions.map((record) => (
+                            <ScriptExecutionCard key={record.execution.id} record={record} />
+                        ))}
+                    </div>
+                )}
+            </div>
+        </Collapsible>
+    );
+}

--- a/src/components/ScriptUploadDialog.test.tsx
+++ b/src/components/ScriptUploadDialog.test.tsx
@@ -1,0 +1,497 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ScriptUploadDialog } from './ScriptUploadDialog';
+import { templateFor } from '@/lib/script-language';
+
+const mockUploadScript = vi.fn();
+
+vi.mock('@/lib/store', () => ({
+    useAppStore: vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
+        selector({
+            uploadScript: mockUploadScript,
+        })
+    ),
+}));
+
+// CodeMirror uses contenteditable and measures layout, neither of which jsdom
+// supports, so the lazily-loaded editor is replaced with a plain textarea
+// that forwards the same value/onChange contract.
+vi.mock('@/components/ScriptEditor', () => ({
+    default: ({ value, onChange, ariaLabel }: { value: string; onChange: (v: string) => void; ariaLabel: string }) => (
+        <textarea
+            data-testid="script-editor"
+            aria-label={ariaLabel}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+        />
+    ),
+}));
+
+function makeFile(content: string[], name = 'script.sh'): File {
+    return new File(content, name, { type: 'text/x-shellscript' });
+}
+
+describe('ScriptUploadDialog', () => {
+    beforeEach(() => {
+        mockUploadScript.mockReset().mockResolvedValue({ id: 'script-1' });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('disables submit until a file is selected', async () => {
+        const user = userEvent.setup();
+        render(
+            <ScriptUploadDialog
+                open
+                onOpenChange={vi.fn()}
+                entityId="ecu"
+                entityType="components"
+                onUploaded={vi.fn()}
+            />
+        );
+
+        const submit = screen.getByRole('button', { name: /^upload$/i });
+        expect(submit).toBeDisabled();
+
+        await user.upload(screen.getByLabelText(/^file$/i), makeFile(['#!/bin/sh\necho hi']));
+        expect(submit).not.toBeDisabled();
+    });
+
+    it('rejects a zero-byte file inline and does not call the store', async () => {
+        const user = userEvent.setup();
+        render(
+            <ScriptUploadDialog
+                open
+                onOpenChange={vi.fn()}
+                entityId="ecu"
+                entityType="components"
+                onUploaded={vi.fn()}
+            />
+        );
+
+        await user.upload(screen.getByLabelText(/^file$/i), makeFile([], 'empty.sh'));
+        await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+        expect(await screen.findByText(/empty/i)).toBeInTheDocument();
+        expect(mockUploadScript).not.toHaveBeenCalled();
+    });
+
+    it('omits the metadata argument when name and description are empty', async () => {
+        const user = userEvent.setup();
+        render(
+            <ScriptUploadDialog
+                open
+                onOpenChange={vi.fn()}
+                entityId="ecu"
+                entityType="components"
+                onUploaded={vi.fn()}
+            />
+        );
+
+        await user.upload(screen.getByLabelText(/^file$/i), makeFile(['#!/bin/sh\necho hi']));
+        await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+        await waitFor(() => {
+            expect(mockUploadScript).toHaveBeenCalledWith('components', 'ecu', expect.any(File));
+        });
+    });
+
+    it('passes name and description as metadata', async () => {
+        const user = userEvent.setup();
+        render(
+            <ScriptUploadDialog
+                open
+                onOpenChange={vi.fn()}
+                entityId="ecu"
+                entityType="components"
+                onUploaded={vi.fn()}
+            />
+        );
+
+        await user.upload(screen.getByLabelText(/^file$/i), makeFile(['#!/bin/sh\necho hi']));
+        await user.type(screen.getByLabelText(/^name$/i), 'Diagnostics');
+        await user.type(screen.getByLabelText(/^description$/i), 'Checks sensors');
+        await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+        await waitFor(() => {
+            expect(mockUploadScript).toHaveBeenCalledWith('components', 'ecu', expect.any(File), {
+                name: 'Diagnostics',
+                description: 'Checks sensors',
+            });
+        });
+    });
+
+    it('disables submit while the upload is in flight and calls the store once', async () => {
+        let resolveUpload: ((value: { id: string }) => void) | undefined;
+        mockUploadScript.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveUpload = resolve;
+                })
+        );
+
+        const user = userEvent.setup();
+        render(
+            <ScriptUploadDialog
+                open
+                onOpenChange={vi.fn()}
+                entityId="ecu"
+                entityType="components"
+                onUploaded={vi.fn()}
+            />
+        );
+
+        await user.upload(screen.getByLabelText(/^file$/i), makeFile(['#!/bin/sh\necho hi']));
+        const submit = screen.getByRole('button', { name: /^upload$/i });
+        await user.click(submit);
+
+        await waitFor(() => {
+            expect(submit).toBeDisabled();
+        });
+        expect(mockUploadScript).toHaveBeenCalledTimes(1);
+
+        resolveUpload?.({ id: 'script-1' });
+        await waitFor(() => {
+            expect(submit).not.toBeDisabled();
+        });
+        expect(mockUploadScript).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the dialog open and shows the gateway message on 413', async () => {
+        const { ScriptsApiError } = await import('@/lib/scripts');
+        mockUploadScript.mockRejectedValueOnce(new ScriptsApiError('Script exceeds the size limit', 413, ''));
+        const onOpenChange = vi.fn();
+
+        const user = userEvent.setup();
+        render(
+            <ScriptUploadDialog
+                open
+                onOpenChange={onOpenChange}
+                entityId="ecu"
+                entityType="components"
+                onUploaded={vi.fn()}
+            />
+        );
+
+        await user.upload(screen.getByLabelText(/^file$/i), makeFile(['#!/bin/sh\necho hi']));
+        await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent(/script exceeds the size limit/i);
+        expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it('shows the gateway message when uploads are disabled', async () => {
+        const { ScriptsApiError } = await import('@/lib/scripts');
+        mockUploadScript.mockRejectedValueOnce(
+            new ScriptsApiError('Script uploads are disabled', 400, 'invalid-request')
+        );
+
+        const user = userEvent.setup();
+        render(
+            <ScriptUploadDialog
+                open
+                onOpenChange={vi.fn()}
+                entityId="ecu"
+                entityType="components"
+                onUploaded={vi.fn()}
+            />
+        );
+
+        await user.upload(screen.getByLabelText(/^file$/i), makeFile(['#!/bin/sh\necho hi']));
+        await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent(/script uploads are disabled/i);
+    });
+
+    it('falls back to a default message when the error carries none', async () => {
+        mockUploadScript.mockRejectedValueOnce(new Error());
+
+        const user = userEvent.setup();
+        render(
+            <ScriptUploadDialog
+                open
+                onOpenChange={vi.fn()}
+                entityId="ecu"
+                entityType="components"
+                onUploaded={vi.fn()}
+            />
+        );
+
+        await user.upload(screen.getByLabelText(/^file$/i), makeFile(['#!/bin/sh\necho hi']));
+        await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+        expect(await screen.findByRole('alert')).toHaveTextContent(/upload failed/i);
+    });
+
+    it('calls onUploaded and closes on success', async () => {
+        const onUploaded = vi.fn();
+        const onOpenChange = vi.fn();
+
+        const user = userEvent.setup();
+        render(
+            <ScriptUploadDialog
+                open
+                onOpenChange={onOpenChange}
+                entityId="ecu"
+                entityType="components"
+                onUploaded={onUploaded}
+            />
+        );
+
+        await user.upload(screen.getByLabelText(/^file$/i), makeFile(['#!/bin/sh\necho hi']));
+        await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+        await waitFor(() => {
+            expect(onUploaded).toHaveBeenCalled();
+            expect(onOpenChange).toHaveBeenCalledWith(false);
+        });
+    });
+
+    it('opens in upload-file mode and behaves exactly as before', async () => {
+        render(
+            <ScriptUploadDialog
+                open
+                onOpenChange={vi.fn()}
+                entityId="ecu"
+                entityType="components"
+                onUploaded={vi.fn()}
+            />
+        );
+
+        expect(screen.getByLabelText(/^file$/i)).toBeInTheDocument();
+        expect(screen.queryByLabelText(/file name/i)).not.toBeInTheDocument();
+        expect(screen.queryByTestId('script-editor')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /^upload$/i })).toBeDisabled();
+    });
+
+    describe('write mode', () => {
+        async function openInWriteMode(): Promise<ReturnType<typeof userEvent.setup>> {
+            const user = userEvent.setup();
+            render(
+                <ScriptUploadDialog
+                    open
+                    onOpenChange={vi.fn()}
+                    entityId="ecu"
+                    entityType="components"
+                    onUploaded={vi.fn()}
+                />
+            );
+            await user.click(screen.getByRole('button', { name: /write script/i }));
+            return user;
+        }
+
+        it('shows the editor and the file name field in write mode', async () => {
+            await openInWriteMode();
+
+            expect(await screen.findByTestId('script-editor')).toBeInTheDocument();
+            expect(screen.getByLabelText(/file name/i)).toBeInTheDocument();
+            expect(screen.queryByLabelText(/^file$/i)).not.toBeInTheDocument();
+        });
+
+        it('gives the editor an accessible name so it is reachable as a textbox', async () => {
+            await openInWriteMode();
+
+            // Regression guard: the visible "Script" caption is not
+            // htmlFor-associated (CodeMirror's contenteditable, not a native
+            // form control, is what actually needs the name), so this must
+            // come from the editor's own ariaLabel prop. "Script content"
+            // rather than just "Script": that would be a substring of
+            // "Description" ("de-script-ion") and collide with it.
+            expect(await screen.findByRole('textbox', { name: 'Script content' })).toBe(
+                screen.getByTestId('script-editor')
+            );
+        });
+
+        it('inserts the bash template when entering write mode with an empty editor', async () => {
+            await openInWriteMode();
+
+            const editor = await screen.findByTestId('script-editor');
+            await waitFor(() => {
+                expect(editor).toHaveValue(templateFor(''));
+            });
+        });
+
+        it('inserts the python template when the file name ends in .py', async () => {
+            const user = await openInWriteMode();
+
+            await user.type(screen.getByLabelText(/file name/i), 'check.py');
+
+            const editor = await screen.findByTestId('script-editor');
+            await waitFor(() => {
+                expect(editor).toHaveValue(templateFor('check.py'));
+            });
+        });
+
+        it('does not overwrite content the user already typed when the file name changes', async () => {
+            const user = await openInWriteMode();
+
+            const editor = await screen.findByTestId('script-editor');
+            await user.clear(editor);
+            await user.type(editor, 'echo custom-content');
+
+            await user.type(screen.getByLabelText(/file name/i), 'check.py');
+
+            expect(editor).toHaveValue('echo custom-content');
+        });
+
+        it('keeps submit disabled until both a file name and content are present', async () => {
+            const user = await openInWriteMode();
+            const editor = await screen.findByTestId('script-editor');
+
+            const submit = screen.getByRole('button', { name: /^upload$/i });
+            expect(submit).toBeDisabled();
+
+            await user.type(screen.getByLabelText(/file name/i), 'check.sh');
+            expect(submit).not.toBeDisabled();
+
+            // The file name alone is not enough either: clearing the
+            // auto-inserted template back down to zero length must re-disable
+            // submit even though a valid file name is already in place.
+            await user.clear(editor);
+            expect(submit).toBeDisabled();
+        });
+
+        it('rejects whitespace-only content inline and does not call the store', async () => {
+            const user = await openInWriteMode();
+            await user.type(screen.getByLabelText(/file name/i), 'check.sh');
+
+            const editor = await screen.findByTestId('script-editor');
+            await user.clear(editor);
+            await user.type(editor, '   ');
+
+            await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+            expect(await screen.findByText(/content is empty/i)).toBeInTheDocument();
+            expect(mockUploadScript).not.toHaveBeenCalled();
+        });
+
+        it('rejects a file name without an extension inline and does not call the store', async () => {
+            const user = await openInWriteMode();
+            await screen.findByTestId('script-editor');
+
+            await user.type(screen.getByLabelText(/file name/i), 'checkscript');
+            await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+            expect(await screen.findByRole('alert')).toHaveTextContent(/needs an extension/i);
+            expect(mockUploadScript).not.toHaveBeenCalled();
+        });
+
+        it('clears the inline error as soon as the file name is edited', async () => {
+            const user = await openInWriteMode();
+            await screen.findByTestId('script-editor');
+            const fileName = screen.getByLabelText(/file name/i);
+
+            await user.type(fileName, 'checkscript');
+            await user.click(screen.getByRole('button', { name: /^upload$/i }));
+            expect(await screen.findByRole('alert')).toHaveTextContent(/needs an extension/i);
+
+            // Still has no extension, so this could only pass if the error
+            // clears on edit rather than on the next submit.
+            await user.type(fileName, 'x');
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        });
+
+        it('clears the inline error as soon as the editor content is edited', async () => {
+            const user = await openInWriteMode();
+            const editor = await screen.findByTestId('script-editor');
+            await user.type(screen.getByLabelText(/file name/i), 'check.sh');
+
+            await user.clear(editor);
+            await user.type(editor, '   ');
+            await user.click(screen.getByRole('button', { name: /^upload$/i }));
+            expect(await screen.findByRole('alert')).toHaveTextContent(/content is empty/i);
+
+            await user.type(editor, 'echo hi');
+            expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        });
+
+        it('uploads a File built from the typed content and file name', async () => {
+            const user = await openInWriteMode();
+            await user.type(screen.getByLabelText(/file name/i), 'my-check.sh');
+
+            const editor = await screen.findByTestId('script-editor');
+            await user.clear(editor);
+            await user.type(editor, 'echo custom-content');
+
+            await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+            await waitFor(() => {
+                expect(mockUploadScript).toHaveBeenCalledTimes(1);
+            });
+            const call = mockUploadScript.mock.calls[0];
+            if (!call) throw new Error('uploadScript was not called');
+            const uploadedFile = call[2] as File;
+            expect(uploadedFile.name).toBe('my-check.sh');
+            await expect(uploadedFile.text()).resolves.toBe('echo custom-content');
+        });
+
+        it('trims surrounding whitespace from the file name before uploading', async () => {
+            const user = await openInWriteMode();
+            await user.type(screen.getByLabelText(/file name/i), '  my-check.sh  ');
+            await screen.findByTestId('script-editor');
+
+            await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+            await waitFor(() => {
+                expect(mockUploadScript).toHaveBeenCalledTimes(1);
+            });
+            const call = mockUploadScript.mock.calls[0];
+            if (!call) throw new Error('uploadScript was not called');
+            const uploadedFile = call[2] as File;
+            expect(uploadedFile.name).toBe('my-check.sh');
+        });
+
+        it('omits metadata when display name and description are empty', async () => {
+            const user = await openInWriteMode();
+            await user.type(screen.getByLabelText(/file name/i), 'my-check.sh');
+            await screen.findByTestId('script-editor');
+
+            await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+            await waitFor(() => {
+                expect(mockUploadScript).toHaveBeenCalledWith('components', 'ecu', expect.any(File));
+            });
+        });
+
+        it('keeps display name and description when switching modes', async () => {
+            const user = userEvent.setup();
+            render(
+                <ScriptUploadDialog
+                    open
+                    onOpenChange={vi.fn()}
+                    entityId="ecu"
+                    entityType="components"
+                    onUploaded={vi.fn()}
+                />
+            );
+
+            await user.type(screen.getByLabelText(/^name$/i), 'Diagnostics');
+            await user.type(screen.getByLabelText(/^description$/i), 'Checks sensors');
+
+            await user.click(screen.getByRole('button', { name: /write script/i }));
+            expect(screen.getByLabelText(/^name$/i)).toHaveValue('Diagnostics');
+            expect(screen.getByLabelText(/^description$/i)).toHaveValue('Checks sensors');
+
+            await user.click(screen.getByRole('button', { name: /from file/i }));
+            expect(screen.getByLabelText(/^name$/i)).toHaveValue('Diagnostics');
+            expect(screen.getByLabelText(/^description$/i)).toHaveValue('Checks sensors');
+        });
+    });
+});

--- a/src/components/ScriptUploadDialog.test.tsx
+++ b/src/components/ScriptUploadDialog.test.tsx
@@ -393,6 +393,32 @@ describe('ScriptUploadDialog', () => {
             expect(mockUploadScript).not.toHaveBeenCalled();
         });
 
+        it('rejects a path traversal file name inline and does not call the store', async () => {
+            const user = await openInWriteMode();
+            await screen.findByTestId('script-editor');
+
+            await user.type(screen.getByLabelText(/file name/i), '../../etc/cron.d/evil.sh');
+            await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+            expect(await screen.findByRole('alert')).toHaveTextContent(/plain file name/i);
+            expect(mockUploadScript).not.toHaveBeenCalled();
+        });
+
+        it('rejects a name with a dot in an earlier path segment, since it has no real extension', async () => {
+            // extensionOf must read the last path segment only: my.dir/check
+            // has a dot before the separator but no extension on `check`
+            // itself, so this must fail basename validation, not slip
+            // through as if it had a usable extension.
+            const user = await openInWriteMode();
+            await screen.findByTestId('script-editor');
+
+            await user.type(screen.getByLabelText(/file name/i), 'my.dir/check');
+            await user.click(screen.getByRole('button', { name: /^upload$/i }));
+
+            expect(await screen.findByRole('alert')).toHaveTextContent(/plain file name/i);
+            expect(mockUploadScript).not.toHaveBeenCalled();
+        });
+
         it('clears the inline error as soon as the file name is edited', async () => {
             const user = await openInWriteMode();
             await screen.findByTestId('script-editor');
@@ -492,6 +518,105 @@ describe('ScriptUploadDialog', () => {
             await user.click(screen.getByRole('button', { name: /from file/i }));
             expect(screen.getByLabelText(/^name$/i)).toHaveValue('Diagnostics');
             expect(screen.getByLabelText(/^description$/i)).toHaveValue('Checks sensors');
+        });
+    });
+
+    describe('dismissing with unsaved write-mode content', () => {
+        async function openInWriteModeWith(
+            onOpenChange: (open: boolean) => void
+        ): Promise<ReturnType<typeof userEvent.setup>> {
+            const user = userEvent.setup();
+            render(
+                <ScriptUploadDialog
+                    open
+                    onOpenChange={onOpenChange}
+                    entityId="ecu"
+                    entityType="components"
+                    onUploaded={vi.fn()}
+                />
+            );
+            await user.click(screen.getByRole('button', { name: /write script/i }));
+            return user;
+        }
+
+        async function typeCustomContent(): Promise<{
+            user: ReturnType<typeof userEvent.setup>;
+            editor: HTMLElement;
+        }> {
+            const user = userEvent.setup();
+            const editor = await screen.findByTestId('script-editor');
+            await user.clear(editor);
+            await user.type(editor, 'echo custom-content');
+            return { user, editor };
+        }
+
+        it('keeps the dialog open on Escape when the user declines to discard typed content', async () => {
+            const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+            const onOpenChange = vi.fn();
+            const user = await openInWriteModeWith(onOpenChange);
+            const { editor } = await typeCustomContent();
+
+            await user.keyboard('{Escape}');
+
+            expect(confirmSpy).toHaveBeenCalled();
+            expect(onOpenChange).not.toHaveBeenCalledWith(false);
+            expect(editor).toHaveValue('echo custom-content');
+        });
+
+        it('closes on Escape once the user confirms discarding typed content', async () => {
+            vi.spyOn(window, 'confirm').mockReturnValue(true);
+            const onOpenChange = vi.fn();
+            const user = await openInWriteModeWith(onOpenChange);
+            await typeCustomContent();
+
+            await user.keyboard('{Escape}');
+
+            expect(onOpenChange).toHaveBeenCalledWith(false);
+        });
+
+        it('closes on Escape without prompting while the editor still holds only the auto-inserted template', async () => {
+            const confirmSpy = vi.spyOn(window, 'confirm');
+            const onOpenChange = vi.fn();
+            const user = await openInWriteModeWith(onOpenChange);
+            await screen.findByTestId('script-editor');
+
+            await user.keyboard('{Escape}');
+
+            expect(confirmSpy).not.toHaveBeenCalled();
+            expect(onOpenChange).toHaveBeenCalledWith(false);
+        });
+
+        it('prompts before discarding when Cancel is clicked with typed content, and stays open when declined', async () => {
+            const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+            const onOpenChange = vi.fn();
+            const user = await openInWriteModeWith(onOpenChange);
+            await typeCustomContent();
+
+            await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+            expect(confirmSpy).toHaveBeenCalled();
+            expect(onOpenChange).not.toHaveBeenCalledWith(false);
+        });
+
+        it('does not prompt when Cancel is clicked in upload-file mode with a file selected', async () => {
+            const confirmSpy = vi.spyOn(window, 'confirm');
+            const onOpenChange = vi.fn();
+            const user = userEvent.setup();
+            render(
+                <ScriptUploadDialog
+                    open
+                    onOpenChange={onOpenChange}
+                    entityId="ecu"
+                    entityType="components"
+                    onUploaded={vi.fn()}
+                />
+            );
+            await user.upload(screen.getByLabelText(/^file$/i), makeFile(['#!/bin/sh\necho hi']));
+
+            await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+            expect(confirmSpy).not.toHaveBeenCalled();
+            expect(onOpenChange).toHaveBeenCalledWith(false);
         });
     });
 });

--- a/src/components/ScriptUploadDialog.tsx
+++ b/src/components/ScriptUploadDialog.tsx
@@ -27,7 +27,7 @@ import {
 } from '@/components/ui/dialog';
 import { useAppStore } from '@/lib/store';
 import { scriptErrorMessage } from '@/lib/scripts';
-import { hasExtension, templateFor } from '@/lib/script-language';
+import { hasExtension, isPlainBasename, templateFor } from '@/lib/script-language';
 import type { ScriptEntityType, ScriptUploadMetadata } from '@/lib/types';
 
 // Defined once at module scope: creating the lazy wrapper inside the component
@@ -164,6 +164,15 @@ export function ScriptUploadDialog({ open, onOpenChange, entityId, entityType, o
             return;
         }
         const trimmedFileName = writeFileName.trim();
+        // Checked before hasExtension, and independently of it: the name ends
+        // up verbatim in the multipart upload's filename field, which the
+        // gateway uses to name a file on the robot. A path (../../etc/cron.d/evil.sh)
+        // must never reach that request, regardless of whether it happens to
+        // carry something that looks like an extension too.
+        if (!isPlainBasename(trimmedFileName)) {
+            setError('File name must be a plain file name, with no path separators');
+            return;
+        }
         if (!hasExtension(trimmedFileName)) {
             setError('File name needs an extension, e.g. check.sh or check.py');
             return;
@@ -178,19 +187,54 @@ export function ScriptUploadDialog({ open, onOpenChange, entityId, entityType, o
     const submitDisabled =
         submitting || (mode === 'write' ? !writeFileName.trim() || writeContent.length === 0 : !file);
 
+    /**
+     * Gate for every way this dialog can be dismissed while write mode holds
+     * content the user actually typed (contentTouchedRef, not just a
+     * pristine auto-inserted template). Returns false to keep the dialog
+     * open. Not gated on the upload-file mode: a merely *selected* file is
+     * trivial to reselect and was never at risk of being "lost work".
+     */
+    const requestDismiss = (): boolean => {
+        if (submitting) return false;
+        if (mode === 'write' && contentTouchedRef.current && writeContent.trim() !== '') {
+            return window.confirm('Discard the script you wrote? This cannot be undone.');
+        }
+        return true;
+    };
+
+    const dismiss = () => {
+        if (requestDismiss()) onOpenChange(false);
+    };
+
     return (
         <Dialog
             open={open}
             onOpenChange={(next) => {
-                if (next || submitting) return;
-                onOpenChange(false);
+                // Reached by the dialog's visible X close button, which
+                // (unlike Escape or an outside click) is not routed through
+                // the DismissableLayer callbacks below, so it is not
+                // pre-empted by their preventDefault() and lands here directly.
+                if (next) return;
+                dismiss();
             }}
         >
             <DialogContent
                 className="max-h-[80vh] overflow-y-auto"
-                onEscapeKeyDown={(e) => submitting && e.preventDefault()}
-                onPointerDownOutside={(e) => submitting && e.preventDefault()}
-                onInteractOutside={(e) => submitting && e.preventDefault()}
+                onEscapeKeyDown={(e) => {
+                    // Always pre-empt Radix's own dismissal so the decision is
+                    // made exactly once, here, instead of a second time when
+                    // the resulting close reaches the Dialog's onOpenChange above.
+                    e.preventDefault();
+                    dismiss();
+                }}
+                onPointerDownOutside={(e) => {
+                    e.preventDefault();
+                    dismiss();
+                }}
+                onInteractOutside={(e) => {
+                    e.preventDefault();
+                    dismiss();
+                }}
             >
                 <DialogHeader>
                     <DialogTitle>Upload Script</DialogTitle>
@@ -299,7 +343,7 @@ export function ScriptUploadDialog({ open, onOpenChange, entityId, entityType, o
                     )}
                 </div>
                 <DialogFooter>
-                    <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+                    <Button variant="outline" onClick={dismiss} disabled={submitting}>
                         Cancel
                     </Button>
                     <Button onClick={() => void handleSubmit()} disabled={submitDisabled}>

--- a/src/components/ScriptUploadDialog.tsx
+++ b/src/components/ScriptUploadDialog.tsx
@@ -1,0 +1,319 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { useAppStore } from '@/lib/store';
+import { scriptErrorMessage } from '@/lib/scripts';
+import { hasExtension, templateFor } from '@/lib/script-language';
+import type { ScriptEntityType, ScriptUploadMetadata } from '@/lib/types';
+
+// Defined once at module scope: creating the lazy wrapper inside the component
+// would hand React a new component identity on every render and remount the
+// editor (and its internal CodeMirror state) each time.
+const ScriptEditor = lazy(() => import('@/components/ScriptEditor'));
+
+type DialogMode = 'upload' | 'write';
+
+interface ScriptUploadDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    entityId: string;
+    entityType: ScriptEntityType;
+    onUploaded: () => void;
+}
+
+/**
+ * Dialog for adding a new script to an app or component, either by uploading
+ * a file that already exists on disk or by writing one directly in the
+ * browser with a CodeMirror editor.
+ *
+ * The gateway exposes no flag telling the UI whether uploads are enabled, so
+ * the Upload button is always available and a rejected request (400 disabled,
+ * 413 too large, ...) is the only signal. Errors are shown inline and the
+ * dialog stays open on failure so the user can pick a different file (or
+ * fix what they wrote), without losing what they already typed.
+ */
+export function ScriptUploadDialog({ open, onOpenChange, entityId, entityType, onUploaded }: ScriptUploadDialogProps) {
+    const uploadScript = useAppStore((state) => state.uploadScript);
+
+    const [mode, setMode] = useState<DialogMode>('upload');
+
+    const [file, setFile] = useState<File | null>(null);
+
+    const [writeFileName, setWriteFileName] = useState('');
+    const [writeContent, setWriteContent] = useState('');
+    // True once the user has actually typed in the editor. Guards the
+    // auto-template effect below: it may fill a still-pristine editor when
+    // the file name changes, but must never clobber real content.
+    const contentTouchedRef = useRef(false);
+
+    const [name, setName] = useState('');
+    const [description, setDescription] = useState('');
+    const [error, setError] = useState<string | null>(null);
+    const [submitting, setSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (!open) {
+            setMode('upload');
+            setFile(null);
+            setWriteFileName('');
+            setWriteContent('');
+            contentTouchedRef.current = false;
+            setName('');
+            setDescription('');
+            setError(null);
+            setSubmitting(false);
+        }
+    }, [open]);
+
+    // Seeds the editor with a starter template while it is still pristine.
+    // Runs again whenever the file name changes so that switching a name
+    // between, say, check.py and check.sh keeps the template's language in
+    // sync - but only until the user actually types, at which point
+    // contentTouchedRef stops it from ever overwriting their work.
+    useEffect(() => {
+        if (mode !== 'write') return;
+        if (contentTouchedRef.current) return;
+        setWriteContent(templateFor(writeFileName));
+    }, [mode, writeFileName]);
+
+    const switchMode = (next: DialogMode) => {
+        if (next === mode) return;
+        setMode(next);
+        setFile(null);
+        setWriteFileName('');
+        setWriteContent('');
+        contentTouchedRef.current = false;
+        setError(null);
+    };
+
+    const handleContentChange = (value: string) => {
+        contentTouchedRef.current = true;
+        setWriteContent(value);
+        setError(null);
+    };
+
+    const metadataFor = (): ScriptUploadMetadata | undefined => {
+        const trimmedName = name.trim();
+        const trimmedDescription = description.trim();
+        return trimmedName || trimmedDescription
+            ? { name: trimmedName || undefined, description: trimmedDescription || undefined }
+            : undefined;
+    };
+
+    const submitFile = async (fileToUpload: File) => {
+        const metadata = metadataFor();
+        setSubmitting(true);
+        try {
+            if (metadata) {
+                await uploadScript(entityType, entityId, fileToUpload, metadata);
+            } else {
+                await uploadScript(entityType, entityId, fileToUpload);
+            }
+            onUploaded();
+            onOpenChange(false);
+        } catch (err) {
+            setError(scriptErrorMessage(err, 'Upload failed'));
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const handleUploadSubmit = async () => {
+        if (!file) return;
+        setError(null);
+
+        // The gateway does not reject an empty file; it would store it as an
+        // unusable script, so catch it here before the request is made.
+        if (file.size === 0) {
+            setError('The selected file is empty');
+            return;
+        }
+
+        await submitFile(file);
+    };
+
+    const handleWriteSubmit = async () => {
+        setError(null);
+
+        if (writeContent.trim() === '') {
+            setError('Script content is empty');
+            return;
+        }
+        const trimmedFileName = writeFileName.trim();
+        if (!hasExtension(trimmedFileName)) {
+            setError('File name needs an extension, e.g. check.sh or check.py');
+            return;
+        }
+
+        const file = new File([writeContent], trimmedFileName, { type: 'text/plain' });
+        await submitFile(file);
+    };
+
+    const handleSubmit = () => (mode === 'write' ? handleWriteSubmit() : handleUploadSubmit());
+
+    const submitDisabled =
+        submitting || (mode === 'write' ? !writeFileName.trim() || writeContent.length === 0 : !file);
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(next) => {
+                if (next || submitting) return;
+                onOpenChange(false);
+            }}
+        >
+            <DialogContent
+                className="max-h-[80vh] overflow-y-auto"
+                onEscapeKeyDown={(e) => submitting && e.preventDefault()}
+                onPointerDownOutside={(e) => submitting && e.preventDefault()}
+                onInteractOutside={(e) => submitting && e.preventDefault()}
+            >
+                <DialogHeader>
+                    <DialogTitle>Upload Script</DialogTitle>
+                    <DialogDescription>
+                        {mode === 'write'
+                            ? 'Write a new script for this entity. Name and description are optional and shown alongside the script.'
+                            : 'Upload a new script file for this entity. Name and description are optional and shown alongside the script.'}
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-3">
+                    <div className="flex gap-1 rounded-md border p-1">
+                        <Button
+                            type="button"
+                            variant={mode === 'upload' ? 'secondary' : 'ghost'}
+                            size="sm"
+                            className="flex-1"
+                            disabled={submitting}
+                            onClick={() => switchMode('upload')}
+                        >
+                            From file
+                        </Button>
+                        <Button
+                            type="button"
+                            variant={mode === 'write' ? 'secondary' : 'ghost'}
+                            size="sm"
+                            className="flex-1"
+                            disabled={submitting}
+                            onClick={() => switchMode('write')}
+                        >
+                            Write script
+                        </Button>
+                    </div>
+
+                    {mode === 'upload' ? (
+                        <div>
+                            <Label htmlFor="script-upload-file">File</Label>
+                            <input
+                                id="script-upload-file"
+                                type="file"
+                                onChange={(e) => {
+                                    setFile(e.target.files?.[0] ?? null);
+                                    setError(null);
+                                }}
+                                aria-invalid={!!error}
+                                aria-describedby={error ? 'script-upload-error' : undefined}
+                                className="border-input file:text-foreground flex h-9 w-full min-w-0 rounded-md border bg-transparent text-sm shadow-xs outline-none file:mr-3 file:h-full file:border-0 file:bg-muted file:px-3 file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+                            />
+                        </div>
+                    ) : (
+                        <>
+                            <div>
+                                <Label htmlFor="script-write-filename">File name</Label>
+                                <Input
+                                    id="script-write-filename"
+                                    placeholder="check-sensors.sh"
+                                    value={writeFileName}
+                                    onChange={(e) => {
+                                        setWriteFileName(e.target.value);
+                                        setError(null);
+                                    }}
+                                    aria-invalid={!!error}
+                                    aria-describedby={error ? 'script-upload-error' : undefined}
+                                />
+                                <p className="mt-1 text-xs text-muted-foreground">
+                                    The extension selects the interpreter: .py runs under python3, .bash under bash,
+                                    anything else under sh.
+                                </p>
+                            </div>
+                            <div>
+                                {/* Not htmlFor-associated: CodeMirror's contenteditable carries its
+                                    own accessible name via ScriptEditor's ariaLabel prop, so this is
+                                    a plain visual caption rather than a functional label target. */}
+                                <Label>Script</Label>
+                                <Suspense fallback={<div className="h-[240px] w-full rounded-md border bg-muted/30" />}>
+                                    <ScriptEditor
+                                        value={writeContent}
+                                        onChange={handleContentChange}
+                                        filename={writeFileName}
+                                        // Not just "Script": that is a substring of "Description"
+                                        // ("de-script-ion"), which made the two fields ambiguous
+                                        // under substring-based accessible-name matching.
+                                        ariaLabel="Script content"
+                                        disabled={submitting}
+                                    />
+                                </Suspense>
+                            </div>
+                        </>
+                    )}
+
+                    <div>
+                        <Label htmlFor="script-upload-name">Name</Label>
+                        <Input id="script-upload-name" value={name} onChange={(e) => setName(e.target.value)} />
+                    </div>
+                    <div>
+                        <Label htmlFor="script-upload-description">Description</Label>
+                        <Input
+                            id="script-upload-description"
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)}
+                        />
+                    </div>
+                    {error && (
+                        <p id="script-upload-error" role="alert" className="text-sm text-destructive">
+                            {error}
+                        </p>
+                    )}
+                </div>
+                <DialogFooter>
+                    <Button variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+                        Cancel
+                    </Button>
+                    <Button onClick={() => void handleSubmit()} disabled={submitDisabled}>
+                        {submitting ? (
+                            <>
+                                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                                Uploading...
+                            </>
+                        ) : (
+                            'Upload'
+                        )}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/src/components/ScriptsPanel.test.tsx
+++ b/src/components/ScriptsPanel.test.tsx
@@ -229,6 +229,36 @@ describe('ScriptsPanel', () => {
         });
     });
 
+    it('keeps the existing rows on screen while a same-entity refresh is in flight', async () => {
+        let resolveSecond: (value: ScriptsFetchResult) => void = () => {};
+        mockFetchEntityScripts.mockResolvedValueOnce({ items: [makeScript({ id: 'a' })] }).mockImplementationOnce(
+            () =>
+                new Promise<ScriptsFetchResult>((resolve) => {
+                    resolveSecond = resolve;
+                })
+        );
+
+        render(<ScriptsPanel entityId="ecu" entityType="components" />);
+        await waitFor(() => {
+            expect(screen.getByTestId('script-row-a')).toBeInTheDocument();
+        });
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('button', { name: /refresh/i }));
+
+        // The refetch above is for the same entity, so the row already on
+        // screen must stay mounted and the loading spinner must not replace
+        // it - unmounting it here is exactly what would collapse an expanded
+        // row's in-progress parameter form back to nothing.
+        expect(screen.getByTestId('script-row-a')).toBeInTheDocument();
+        expect(screen.queryByText(/Loading scripts/i)).not.toBeInTheDocument();
+
+        await act(async () => {
+            resolveSecond({ items: [makeScript({ id: 'a' })] });
+            await Promise.resolve();
+        });
+    });
+
     it('reloads the list after a successful upload', async () => {
         mockFetchEntityScripts
             .mockResolvedValueOnce({ items: [] })

--- a/src/components/ScriptsPanel.test.tsx
+++ b/src/components/ScriptsPanel.test.tsx
@@ -1,0 +1,298 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ScriptsPanel } from './ScriptsPanel';
+import type { ScriptExecution, ScriptExecutionRecord, ScriptMetadata, ScriptsFetchResult } from '@/lib/types';
+
+const mockFetchEntityScripts = vi.fn();
+
+const mockState: {
+    fetchEntityScripts: typeof mockFetchEntityScripts;
+    scriptExecutions: Map<string, ScriptExecutionRecord[]>;
+} = {
+    fetchEntityScripts: mockFetchEntityScripts,
+    scriptExecutions: new Map(),
+};
+
+vi.mock('@/lib/store', () => ({
+    useAppStore: vi.fn((selector: (s: typeof mockState) => unknown) => selector(mockState)),
+}));
+
+// The row's own behaviour (form, run, delete) is covered by ScriptRow.test.tsx.
+// Here we only need to know what props ScriptsPanel hands it.
+vi.mock('@/components/ScriptRow', () => ({
+    ScriptRow: ({
+        script,
+        entityId,
+        entityType,
+        executions,
+        onDeleted,
+    }: {
+        script: ScriptMetadata;
+        entityId: string;
+        entityType: string;
+        executions: ScriptExecutionRecord[];
+        onDeleted: () => void;
+    }) => (
+        <div data-testid={`script-row-${script.id}`}>
+            <span data-testid={`script-row-meta-${script.id}`}>
+                {`${entityType}:${entityId}:${executions.map((r) => r.execution.id).join(',')}`}
+            </span>
+            <button onClick={onDeleted}>{`delete-${script.id}`}</button>
+        </div>
+    ),
+}));
+
+// The dialog's own behaviour (form, validation, submit) is covered by
+// ScriptUploadDialog.test.tsx. Here we only need to trigger onUploaded.
+vi.mock('@/components/ScriptUploadDialog', () => ({
+    ScriptUploadDialog: ({ open, onUploaded }: { open: boolean; onUploaded: () => void }) =>
+        open ? (
+            <div data-testid="upload-dialog">
+                <button onClick={onUploaded}>trigger-uploaded</button>
+            </div>
+        ) : null,
+}));
+
+function makeScript(overrides: Partial<ScriptMetadata> = {}): ScriptMetadata {
+    return {
+        id: 'diag',
+        name: 'Diagnostics',
+        description: 'Runs full diagnostics',
+        managed: false,
+        proximity_proof_required: false,
+        parameters_schema: null,
+        ...overrides,
+    };
+}
+
+function makeRecord(id: string, scriptId: string): ScriptExecutionRecord {
+    return {
+        execution: { id, status: 'running' } as ScriptExecution,
+        scriptId,
+        scriptName: scriptId,
+        entityType: 'components',
+        entityId: 'ecu',
+    };
+}
+
+describe('ScriptsPanel', () => {
+    beforeEach(() => {
+        mockFetchEntityScripts.mockReset();
+        mockState.scriptExecutions = new Map();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('renders one row per script', async () => {
+        mockFetchEntityScripts.mockResolvedValue({
+            items: [makeScript({ id: 'a' }), makeScript({ id: 'b', name: 'Beta' })],
+        } satisfies ScriptsFetchResult);
+
+        render(<ScriptsPanel entityId="ecu" entityType="components" />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('script-row-a')).toBeInTheDocument();
+            expect(screen.getByTestId('script-row-b')).toBeInTheDocument();
+        });
+    });
+
+    it('shows the empty state when the gateway returns no scripts', async () => {
+        mockFetchEntityScripts.mockResolvedValue({ items: [] } satisfies ScriptsFetchResult);
+
+        render(<ScriptsPanel entityId="ecu" entityType="components" />);
+
+        expect(await screen.findByText(/No scripts available for this entity/i)).toBeInTheDocument();
+    });
+
+    it('shows the backend-not-configured state on errorStatus 501', async () => {
+        mockFetchEntityScripts.mockResolvedValue({ items: [], errorStatus: 501 } satisfies ScriptsFetchResult);
+
+        render(<ScriptsPanel entityId="ecu" entityType="components" />);
+
+        expect(await screen.findByText(/Scripts are not configured on this gateway/i)).toBeInTheDocument();
+    });
+
+    it('shows a generic error state on errorStatus 500', async () => {
+        mockFetchEntityScripts.mockResolvedValue({ items: [], errorStatus: 500 } satisfies ScriptsFetchResult);
+
+        render(<ScriptsPanel entityId="ecu" entityType="components" />);
+
+        expect(await screen.findByText(/Failed to load scripts/i)).toBeInTheDocument();
+    });
+
+    it('shows the generic error state on errorStatus -1', async () => {
+        mockFetchEntityScripts.mockResolvedValue({ items: [], errorStatus: -1 } satisfies ScriptsFetchResult);
+
+        render(<ScriptsPanel entityId="ecu" entityType="components" />);
+
+        expect(await screen.findByText(/Failed to load scripts/i)).toBeInTheDocument();
+    });
+
+    it('aborts the in-flight list request when the entity changes', async () => {
+        const abortedSignals: AbortSignal[] = [];
+        mockFetchEntityScripts.mockImplementation((_et: string, _id: string, signal: AbortSignal) => {
+            abortedSignals.push(signal);
+            return new Promise<ScriptsFetchResult>((resolve) => {
+                signal.addEventListener('abort', () => resolve({ items: [] }));
+            });
+        });
+
+        const { rerender } = render(<ScriptsPanel entityId="ecu" entityType="components" />);
+        await waitFor(() => {
+            expect(abortedSignals).toHaveLength(1);
+        });
+
+        rerender(<ScriptsPanel entityId="motor" entityType="apps" />);
+        await waitFor(() => {
+            expect(abortedSignals).toHaveLength(2);
+        });
+
+        expect(abortedSignals[0]?.aborted).toBe(true);
+    });
+
+    it('does not render the previous entity scripts when a stale response resolves late', async () => {
+        let resolveFirst: (value: ScriptsFetchResult) => void = () => {};
+        mockFetchEntityScripts.mockImplementationOnce(
+            () =>
+                new Promise<ScriptsFetchResult>((resolve) => {
+                    resolveFirst = resolve;
+                })
+        );
+
+        const { rerender } = render(<ScriptsPanel entityId="ecu" entityType="components" />);
+        await waitFor(() => {
+            expect(mockFetchEntityScripts).toHaveBeenCalledTimes(1);
+        });
+
+        mockFetchEntityScripts.mockResolvedValueOnce({ items: [makeScript({ id: 'new-script' })] });
+        rerender(<ScriptsPanel entityId="motor" entityType="apps" />);
+        await waitFor(() => {
+            expect(screen.getByTestId('script-row-new-script')).toBeInTheDocument();
+        });
+
+        // Resolve the stale (now-aborted) first request with a different script.
+        await act(async () => {
+            resolveFirst({ items: [makeScript({ id: 'stale-script' })] });
+            await Promise.resolve();
+        });
+
+        expect(screen.queryByTestId('script-row-stale-script')).not.toBeInTheDocument();
+        expect(screen.getByTestId('script-row-new-script')).toBeInTheDocument();
+    });
+
+    it('swallows the AbortError without an unhandled rejection', async () => {
+        mockFetchEntityScripts.mockImplementation(
+            (_et: string, _id: string, signal: AbortSignal) =>
+                new Promise<ScriptsFetchResult>((_resolve, reject) => {
+                    signal.addEventListener('abort', () => {
+                        const err = new Error('aborted');
+                        err.name = 'AbortError';
+                        reject(err);
+                    });
+                })
+        );
+
+        const { rerender, unmount } = render(<ScriptsPanel entityId="ecu" entityType="components" />);
+        await waitFor(() => {
+            expect(mockFetchEntityScripts).toHaveBeenCalledTimes(1);
+        });
+
+        rerender(<ScriptsPanel entityId="motor" entityType="apps" />);
+        await waitFor(() => {
+            expect(mockFetchEntityScripts).toHaveBeenCalledTimes(2);
+        });
+
+        // Unmounting aborts the still-pending second request too. If the
+        // component does not catch AbortError, this leaves an unhandled
+        // rejection that vitest reports as a failure for this test.
+        unmount();
+        await act(async () => {
+            await Promise.resolve();
+        });
+    });
+
+    it('reloads the list after a successful upload', async () => {
+        mockFetchEntityScripts
+            .mockResolvedValueOnce({ items: [] })
+            .mockResolvedValueOnce({ items: [makeScript({ id: 'new' })] });
+
+        render(<ScriptsPanel entityId="ecu" entityType="components" />);
+        expect(await screen.findByText(/No scripts available for this entity/i)).toBeInTheDocument();
+
+        const user = userEvent.setup();
+        await user.click(screen.getByRole('button', { name: /upload/i }));
+        await user.click(screen.getByText('trigger-uploaded'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('script-row-new')).toBeInTheDocument();
+        });
+        expect(mockFetchEntityScripts).toHaveBeenCalledTimes(2);
+    });
+
+    it('reloads the list after a script is deleted', async () => {
+        mockFetchEntityScripts
+            .mockResolvedValueOnce({ items: [makeScript({ id: 'a' })] })
+            .mockResolvedValueOnce({ items: [makeScript({ id: 'b' })] });
+
+        render(<ScriptsPanel entityId="ecu" entityType="components" />);
+        await waitFor(() => {
+            expect(screen.getByTestId('script-row-a')).toBeInTheDocument();
+        });
+
+        const user = userEvent.setup();
+        await user.click(screen.getByText('delete-a'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('script-row-b')).toBeInTheDocument();
+        });
+        expect(mockFetchEntityScripts).toHaveBeenCalledTimes(2);
+    });
+
+    it('passes the entity type through for apps and for components', async () => {
+        mockFetchEntityScripts.mockResolvedValue({ items: [makeScript({ id: 'a' })] });
+
+        const { rerender } = render(<ScriptsPanel entityId="ecu" entityType="components" />);
+        await waitFor(() => {
+            expect(screen.getByTestId('script-row-meta-a')).toHaveTextContent('components:ecu:');
+        });
+
+        rerender(<ScriptsPanel entityId="motor" entityType="apps" />);
+        await waitFor(() => {
+            expect(screen.getByTestId('script-row-meta-a')).toHaveTextContent('apps:motor:');
+        });
+    });
+
+    it('passes only the executions of the matching script to each row', async () => {
+        mockFetchEntityScripts.mockResolvedValue({
+            items: [makeScript({ id: 'a' }), makeScript({ id: 'b' })],
+        });
+        mockState.scriptExecutions = new Map([
+            ['components/ecu', [makeRecord('exec_a', 'a'), makeRecord('exec_b', 'b')]],
+        ]);
+
+        render(<ScriptsPanel entityId="ecu" entityType="components" />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('script-row-meta-a')).toHaveTextContent('components:ecu:exec_a');
+            expect(screen.getByTestId('script-row-meta-b')).toHaveTextContent('components:ecu:exec_b');
+        });
+    });
+});

--- a/src/components/ScriptsPanel.tsx
+++ b/src/components/ScriptsPanel.tsx
@@ -57,18 +57,30 @@ export function ScriptsPanel({ entityId, entityType }: ScriptsPanelProps) {
     const [uploadOpen, setUploadOpen] = useState(false);
 
     const abortRef = useRef<AbortController | null>(null);
+    // Identifies the entity the currently-rendered `scripts` belong to, so a
+    // reload of the *same* entity (Refresh, or the reload after an upload or
+    // a delete) can be told apart from an actual entity switch.
+    const currentEntityKeyRef = useRef<string | null>(null);
 
     useEffect(() => {
         abortRef.current?.abort();
         const controller = new AbortController();
         abortRef.current = controller;
 
-        // Clear whatever the previous entity (or previous attempt) rendered so
-        // it never lingers under the new heading while the fresh request is
-        // in flight.
-        setScripts([]);
-        setErrorStatus(null);
-        setIsLoading(true);
+        const entityKey = `${entityType}:${entityId}`;
+        const isEntityChange = currentEntityKeyRef.current !== entityKey;
+        currentEntityKeyRef.current = entityKey;
+
+        if (isEntityChange) {
+            // Only an actual entity switch discards what is currently shown.
+            // A same-entity reload keeps rendering the existing rows while
+            // the refetch is in flight - clearing them here would unmount
+            // every row (and whatever the user was doing inside one, like a
+            // half-filled parameter form) for the duration of the request.
+            setScripts([]);
+            setErrorStatus(null);
+            setIsLoading(true);
+        }
 
         const load = async () => {
             try {
@@ -79,6 +91,7 @@ export function ScriptsPanel({ entityId, entityType }: ScriptsPanelProps) {
                     setErrorStatus(result.errorStatus);
                 } else {
                     setScripts(result.items);
+                    setErrorStatus(null);
                 }
             } catch (err) {
                 if ((err as { name?: string }).name === 'AbortError') return;

--- a/src/components/ScriptsPanel.tsx
+++ b/src/components/ScriptsPanel.tsx
@@ -1,0 +1,179 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { useEffect, useRef, useState } from 'react';
+import { Loader2, RefreshCw, Terminal, Upload } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ScriptRow } from '@/components/ScriptRow';
+import { ScriptUploadDialog } from '@/components/ScriptUploadDialog';
+import { useAppStore } from '@/lib/store';
+import { scriptEntityKey } from '@/lib/scripts';
+import type { ScriptEntityType, ScriptExecutionRecord, ScriptMetadata } from '@/lib/types';
+
+interface ScriptsPanelProps {
+    entityId: string;
+    entityType: ScriptEntityType;
+}
+
+/**
+ * Module-level constant used as the "no history yet" fallback. A `?? []`
+ * fallback inside the store selector below would build a fresh array on
+ * every read, and zustand 5 treats that as an unstable snapshot and loops
+ * with a getSnapshot warning.
+ */
+const EMPTY_EXECUTIONS: ScriptExecutionRecord[] = [];
+
+/**
+ * Scripts panel: lists the scripts uploaded to this app or component, and
+ * hosts the upload dialog. Each row (`ScriptRow`) owns its own run/delete
+ * controls and execution cards; this panel owns the list fetch, the
+ * empty/error states, and the reload trigger shared by upload and delete.
+ *
+ * The 501 branch ("not configured on this gateway") is defensive: the
+ * Scripts tab itself is gated on the gateway capability, so in practice this
+ * panel only mounts when a script backend exists.
+ */
+export function ScriptsPanel({ entityId, entityType }: ScriptsPanelProps) {
+    const fetchEntityScripts = useAppStore((state) => state.fetchEntityScripts);
+    const stored = useAppStore((state) => state.scriptExecutions.get(scriptEntityKey(entityType, entityId)));
+    const executions = stored ?? EMPTY_EXECUTIONS;
+
+    const [scripts, setScripts] = useState<ScriptMetadata[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [errorStatus, setErrorStatus] = useState<number | null>(null);
+    const [reloadToken, setReloadToken] = useState(0);
+    const [uploadOpen, setUploadOpen] = useState(false);
+
+    const abortRef = useRef<AbortController | null>(null);
+
+    useEffect(() => {
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+
+        // Clear whatever the previous entity (or previous attempt) rendered so
+        // it never lingers under the new heading while the fresh request is
+        // in flight.
+        setScripts([]);
+        setErrorStatus(null);
+        setIsLoading(true);
+
+        const load = async () => {
+            try {
+                const result = await fetchEntityScripts(entityType, entityId, controller.signal);
+                if (controller.signal.aborted) return;
+
+                if (result.errorStatus !== undefined) {
+                    setErrorStatus(result.errorStatus);
+                } else {
+                    setScripts(result.items);
+                }
+            } catch (err) {
+                if ((err as { name?: string }).name === 'AbortError') return;
+                setErrorStatus(-1);
+            } finally {
+                if (!controller.signal.aborted) {
+                    setIsLoading(false);
+                }
+            }
+        };
+
+        void load();
+
+        return () => {
+            abortRef.current?.abort();
+        };
+    }, [entityId, entityType, reloadToken, fetchEntityScripts]);
+
+    const reload = () => setReloadToken((t) => t + 1);
+
+    let body: React.JSX.Element;
+    if (isLoading) {
+        body = (
+            <div className="flex items-center justify-center gap-2 py-8">
+                <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
+                <span className="text-sm text-muted-foreground">Loading scripts...</span>
+            </div>
+        );
+    } else if (errorStatus === 501) {
+        body = (
+            <div className="text-center py-8">
+                <Terminal className="w-8 h-8 mx-auto mb-2 opacity-30" />
+                <p className="text-sm text-muted-foreground">Scripts are not configured on this gateway</p>
+            </div>
+        );
+    } else if (errorStatus !== null) {
+        body = (
+            <div className="text-center py-8 space-y-2">
+                <p className="text-sm text-destructive">Failed to load scripts</p>
+                <button type="button" onClick={reload} className="text-xs underline text-muted-foreground">
+                    Retry
+                </button>
+            </div>
+        );
+    } else if (scripts.length === 0) {
+        body = (
+            <div className="text-center py-8">
+                <Terminal className="w-8 h-8 mx-auto mb-2 opacity-30" />
+                <p className="text-sm text-muted-foreground">No scripts available for this entity</p>
+            </div>
+        );
+    } else {
+        body = (
+            <div className="space-y-2">
+                {scripts.map((script) => (
+                    <ScriptRow
+                        key={script.id}
+                        script={script}
+                        entityId={entityId}
+                        entityType={entityType}
+                        executions={executions.filter((r) => r.scriptId === script.id)}
+                        onDeleted={reload}
+                    />
+                ))}
+            </div>
+        );
+    }
+
+    return (
+        <Card>
+            <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <Terminal className="w-5 h-5 text-muted-foreground" />
+                        <CardTitle className="text-base">Scripts</CardTitle>
+                    </div>
+                    <div className="flex items-center gap-2">
+                        <Button variant="outline" size="sm" onClick={() => setUploadOpen(true)}>
+                            <Upload className="w-4 h-4 mr-1.5" />
+                            Upload
+                        </Button>
+                        <Button variant="ghost" size="sm" onClick={reload} aria-label="Refresh">
+                            <RefreshCw className="w-4 h-4" />
+                        </Button>
+                    </div>
+                </div>
+            </CardHeader>
+            <CardContent>{body}</CardContent>
+            <ScriptUploadDialog
+                open={uploadOpen}
+                onOpenChange={setUploadOpen}
+                entityId={entityId}
+                entityType={entityType}
+                onUploaded={reload}
+            />
+        </Card>
+    );
+}

--- a/src/lib/api-dispatch.test.ts
+++ b/src/lib/api-dispatch.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { SovdResourceEntityType } from './types';
+import type { SovdResourceEntityType, ScriptEntityType } from './types';
 import {
     getEntityDetail,
     getEntityData,
@@ -37,6 +37,14 @@ import {
     getEntityLogs,
     getEntityLogsConfiguration,
     putEntityLogsConfiguration,
+    getEntityScripts,
+    getEntityScript,
+    uploadEntityScript,
+    deleteEntityScript,
+    startScriptExecution,
+    getScriptExecution,
+    controlScriptExecution,
+    deleteScriptExecution,
 } from './api-dispatch';
 
 // ---------------------------------------------------------------------------
@@ -726,5 +734,248 @@ describe('putEntityLogsConfiguration', () => {
             params: { path: { app_id: 'motor' } },
             body: { severity_filter: 'warning', max_entries: 500 },
         });
+    });
+});
+
+// =============================================================================
+// Scripts
+// =============================================================================
+
+const SCRIPT_ENTITY_TYPES: ScriptEntityType[] = ['apps', 'components'];
+
+const SCRIPT_PATHS: Record<ScriptEntityType, { list: string; item: string; execs: string; exec: string }> = {
+    apps: {
+        list: '/apps/{app_id}/scripts',
+        item: '/apps/{app_id}/scripts/{script_id}',
+        execs: '/apps/{app_id}/scripts/{script_id}/executions',
+        exec: '/apps/{app_id}/scripts/{script_id}/executions/{execution_id}',
+    },
+    components: {
+        list: '/components/{component_id}/scripts',
+        item: '/components/{component_id}/scripts/{script_id}',
+        execs: '/components/{component_id}/scripts/{script_id}/executions',
+        exec: '/components/{component_id}/scripts/{script_id}/executions/{execution_id}',
+    },
+};
+
+const SCRIPT_ID_PARAM_MAP: Record<ScriptEntityType, string> = {
+    apps: 'app_id',
+    components: 'component_id',
+};
+
+describe('getEntityScripts', () => {
+    let client: MockClient;
+    beforeEach(() => {
+        client = createMockClient();
+    });
+
+    it.each(SCRIPT_ENTITY_TYPES)('getEntityScripts calls the list path for %s', async (entityType) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await getEntityScripts(client as any, entityType, 'my-entity');
+        expect(client.GET).toHaveBeenCalledTimes(1);
+        const [path, opts] = client.GET.mock.calls[0]!;
+        expect(path).toBe(SCRIPT_PATHS[entityType].list);
+        expect(opts.params.path).toEqual({ [SCRIPT_ID_PARAM_MAP[entityType]]: 'my-entity' });
+    });
+
+    it.each(SCRIPT_ENTITY_TYPES)('getEntityScripts forwards the abort signal for %s', async (entityType) => {
+        const controller = new AbortController();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await getEntityScripts(client as any, entityType, 'my-entity', controller.signal);
+        const opts = client.GET.mock.calls[0]![1];
+        expect(opts.signal).toBe(controller.signal);
+    });
+});
+
+// =============================================================================
+// getEntityScript
+// =============================================================================
+
+describe('getEntityScript', () => {
+    let client: MockClient;
+    beforeEach(() => {
+        client = createMockClient();
+    });
+
+    it.each(SCRIPT_ENTITY_TYPES)('getEntityScript calls the item path for %s', async (entityType) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await getEntityScript(client as any, entityType, 'my-entity', 'script-1');
+        expect(client.GET).toHaveBeenCalledTimes(1);
+        const [path, opts] = client.GET.mock.calls[0]!;
+        expect(path).toBe(SCRIPT_PATHS[entityType].item);
+        expect(opts.params.path).toEqual({
+            [SCRIPT_ID_PARAM_MAP[entityType]]: 'my-entity',
+            script_id: 'script-1',
+        });
+    });
+});
+
+// =============================================================================
+// deleteEntityScript
+// =============================================================================
+
+describe('deleteEntityScript', () => {
+    let client: MockClient;
+    beforeEach(() => {
+        client = createMockClient();
+    });
+
+    it.each(SCRIPT_ENTITY_TYPES)('deleteEntityScript deletes the item path for %s', async (entityType) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await deleteEntityScript(client as any, entityType, 'my-entity', 'script-1');
+        expect(client.DELETE).toHaveBeenCalledTimes(1);
+        const [path, opts] = client.DELETE.mock.calls[0]!;
+        expect(path).toBe(SCRIPT_PATHS[entityType].item);
+        expect(opts.params.path).toEqual({
+            [SCRIPT_ID_PARAM_MAP[entityType]]: 'my-entity',
+            script_id: 'script-1',
+        });
+    });
+});
+
+// =============================================================================
+// startScriptExecution
+// =============================================================================
+
+describe('startScriptExecution', () => {
+    let client: MockClient;
+    beforeEach(() => {
+        client = createMockClient();
+    });
+
+    it.each(SCRIPT_ENTITY_TYPES)('startScriptExecution posts the execution body for %s', async (entityType) => {
+        const request = { execution_type: 'diagnostic', parameters: { foo: 'bar' } };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await startScriptExecution(client as any, entityType, 'my-entity', 'script-1', request);
+        expect(client.POST).toHaveBeenCalledTimes(1);
+        const [path, opts] = client.POST.mock.calls[0]!;
+        expect(path).toBe(SCRIPT_PATHS[entityType].execs);
+        expect(opts.params.path).toEqual({
+            [SCRIPT_ID_PARAM_MAP[entityType]]: 'my-entity',
+            script_id: 'script-1',
+        });
+        expect(opts.body).toEqual(request);
+    });
+});
+
+// =============================================================================
+// getScriptExecution
+// =============================================================================
+
+describe('getScriptExecution', () => {
+    let client: MockClient;
+    beforeEach(() => {
+        client = createMockClient();
+    });
+
+    it.each(SCRIPT_ENTITY_TYPES)('getScriptExecution reads the execution path for %s', async (entityType) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await getScriptExecution(client as any, entityType, 'my-entity', 'script-1', 'exec-1');
+        expect(client.GET).toHaveBeenCalledTimes(1);
+        const [path, opts] = client.GET.mock.calls[0]!;
+        expect(path).toBe(SCRIPT_PATHS[entityType].exec);
+        expect(opts.params.path).toEqual({
+            [SCRIPT_ID_PARAM_MAP[entityType]]: 'my-entity',
+            script_id: 'script-1',
+            execution_id: 'exec-1',
+        });
+    });
+
+    it.each(SCRIPT_ENTITY_TYPES)('getScriptExecution forwards the abort signal for %s', async (entityType) => {
+        const controller = new AbortController();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await getScriptExecution(client as any, entityType, 'my-entity', 'script-1', 'exec-1', controller.signal);
+        const opts = client.GET.mock.calls[0]![1];
+        expect(opts.signal).toBe(controller.signal);
+    });
+});
+
+// =============================================================================
+// controlScriptExecution
+// =============================================================================
+
+describe('controlScriptExecution', () => {
+    let client: MockClient;
+    beforeEach(() => {
+        client = createMockClient();
+    });
+
+    it.each(SCRIPT_ENTITY_TYPES)(
+        'controlScriptExecution puts {action} on the execution path for %s',
+        async (entityType) => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await controlScriptExecution(client as any, entityType, 'my-entity', 'script-1', 'exec-1', 'stop');
+            expect(client.PUT).toHaveBeenCalledTimes(1);
+            const [path, opts] = client.PUT.mock.calls[0]!;
+            expect(path).toBe(SCRIPT_PATHS[entityType].exec);
+            expect(opts.params.path).toEqual({
+                [SCRIPT_ID_PARAM_MAP[entityType]]: 'my-entity',
+                script_id: 'script-1',
+                execution_id: 'exec-1',
+            });
+            expect(opts.body).toEqual({ action: 'stop' });
+        }
+    );
+});
+
+// =============================================================================
+// deleteScriptExecution
+// =============================================================================
+
+describe('deleteScriptExecution', () => {
+    let client: MockClient;
+    beforeEach(() => {
+        client = createMockClient();
+    });
+
+    it.each(SCRIPT_ENTITY_TYPES)('deleteScriptExecution deletes the execution path for %s', async (entityType) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await deleteScriptExecution(client as any, entityType, 'my-entity', 'script-1', 'exec-1');
+        expect(client.DELETE).toHaveBeenCalledTimes(1);
+        const [path, opts] = client.DELETE.mock.calls[0]!;
+        expect(path).toBe(SCRIPT_PATHS[entityType].exec);
+        expect(opts.params.path).toEqual({
+            [SCRIPT_ID_PARAM_MAP[entityType]]: 'my-entity',
+            script_id: 'script-1',
+            execution_id: 'exec-1',
+        });
+    });
+});
+
+// =============================================================================
+// uploadEntityScript
+// =============================================================================
+
+describe('uploadEntityScript', () => {
+    let client: MockClient;
+    beforeEach(() => {
+        client = createMockClient();
+    });
+
+    it.each(SCRIPT_ENTITY_TYPES)('uploadEntityScript posts FormData to the list path for %s', async (entityType) => {
+        const form = new FormData();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await uploadEntityScript(client as any, entityType, 'my-entity', form);
+        expect(client.POST).toHaveBeenCalledTimes(1);
+        const [path, opts] = client.POST.mock.calls[0]!;
+        expect(path).toBe(SCRIPT_PATHS[entityType].list);
+        expect(opts.params.path).toEqual({ [SCRIPT_ID_PARAM_MAP[entityType]]: 'my-entity' });
+    });
+
+    it('uploadEntityScript passes FormData through the body serializer untouched', async () => {
+        const form = new FormData();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await uploadEntityScript(client as any, 'apps', 'my-entity', form);
+        const opts = client.POST.mock.calls[0]![1];
+        expect(opts.body).toBeInstanceOf(FormData);
+        expect(opts.bodySerializer(form)).toBe(form);
+    });
+
+    it('uploadEntityScript sets no content type header in any casing', async () => {
+        const form = new FormData();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await uploadEntityScript(client as any, 'apps', 'my-entity', form);
+        const opts = client.POST.mock.calls[0]![1];
+        expect(Object.keys(opts.headers ?? {}).map((k) => k.toLowerCase())).not.toContain('content-type');
     });
 });

--- a/src/lib/api-dispatch.ts
+++ b/src/lib/api-dispatch.ts
@@ -22,7 +22,7 @@
  */
 
 import type { MedkitClient } from '@selfpatch/ros2-medkit-client-ts';
-import type { SovdResourceEntityType } from './types';
+import type { SovdResourceEntityType, ScriptEntityType, StartScriptExecutionRequest } from './types';
 import type { LogsQueryParams, LogsConfiguration } from './log-types';
 
 // =============================================================================
@@ -620,6 +620,193 @@ export function putEntityLogsConfiguration(
             return client.PUT('/functions/{function_id}/logs/configuration', {
                 params: { path: { function_id: entityId } },
                 body: config,
+            });
+    }
+}
+
+// =============================================================================
+// Scripts
+// =============================================================================
+
+export function getEntityScripts(
+    client: MedkitClient,
+    entityType: ScriptEntityType,
+    entityId: string,
+    signal?: AbortSignal
+) {
+    switch (entityType) {
+        case 'apps':
+            return client.GET('/apps/{app_id}/scripts', { params: { path: { app_id: entityId } }, signal });
+        case 'components':
+            return client.GET('/components/{component_id}/scripts', {
+                params: { path: { component_id: entityId } },
+                signal,
+            });
+    }
+}
+
+export function getEntityScript(
+    client: MedkitClient,
+    entityType: ScriptEntityType,
+    entityId: string,
+    scriptId: string
+) {
+    switch (entityType) {
+        case 'apps':
+            return client.GET('/apps/{app_id}/scripts/{script_id}', {
+                params: { path: { app_id: entityId, script_id: scriptId } },
+            });
+        case 'components':
+            return client.GET('/components/{component_id}/scripts/{script_id}', {
+                params: { path: { component_id: entityId, script_id: scriptId } },
+            });
+    }
+}
+
+/**
+ * Multipart upload.
+ *
+ * The spec declares the body as `{type: object, additionalProperties: true}`, so
+ * the generated type is `{ [key: string]: unknown }` and FormData (a DOM interface)
+ * is not assignable to it. bodySerializer returns the FormData unchanged so fetch
+ * sets Content-Type with the multipart boundary itself - the gateway rejects the
+ * request without it.
+ */
+export function uploadEntityScript(
+    client: MedkitClient,
+    entityType: ScriptEntityType,
+    entityId: string,
+    form: FormData
+) {
+    const body = form as unknown as Record<string, unknown>;
+    const bodySerializer = (value: unknown) => value as FormData;
+    switch (entityType) {
+        case 'apps':
+            return client.POST('/apps/{app_id}/scripts', {
+                params: { path: { app_id: entityId } },
+                body,
+                bodySerializer,
+            });
+        case 'components':
+            return client.POST('/components/{component_id}/scripts', {
+                params: { path: { component_id: entityId } },
+                body,
+                bodySerializer,
+            });
+    }
+}
+
+export function deleteEntityScript(
+    client: MedkitClient,
+    entityType: ScriptEntityType,
+    entityId: string,
+    scriptId: string
+) {
+    switch (entityType) {
+        case 'apps':
+            return client.DELETE('/apps/{app_id}/scripts/{script_id}', {
+                params: { path: { app_id: entityId, script_id: scriptId } },
+            });
+        case 'components':
+            return client.DELETE('/components/{component_id}/scripts/{script_id}', {
+                params: { path: { component_id: entityId, script_id: scriptId } },
+            });
+    }
+}
+
+/**
+ * Start an execution.
+ *
+ * The spec declares this request body as a bare `type: object`, so the generated
+ * type is `Record<string, never>` and any real body fails the type check. The cast
+ * keeps the runtime payload correct; removing it requires a spec fix in the gateway.
+ */
+export function startScriptExecution(
+    client: MedkitClient,
+    entityType: ScriptEntityType,
+    entityId: string,
+    scriptId: string,
+    request: StartScriptExecutionRequest
+) {
+    const body = request as unknown as Record<string, never>;
+    switch (entityType) {
+        case 'apps':
+            return client.POST('/apps/{app_id}/scripts/{script_id}/executions', {
+                params: { path: { app_id: entityId, script_id: scriptId } },
+                body,
+            });
+        case 'components':
+            return client.POST('/components/{component_id}/scripts/{script_id}/executions', {
+                params: { path: { component_id: entityId, script_id: scriptId } },
+                body,
+            });
+    }
+}
+
+export function getScriptExecution(
+    client: MedkitClient,
+    entityType: ScriptEntityType,
+    entityId: string,
+    scriptId: string,
+    executionId: string,
+    signal?: AbortSignal
+) {
+    switch (entityType) {
+        case 'apps':
+            return client.GET('/apps/{app_id}/scripts/{script_id}/executions/{execution_id}', {
+                params: { path: { app_id: entityId, script_id: scriptId, execution_id: executionId } },
+                signal,
+            });
+        case 'components':
+            return client.GET('/components/{component_id}/scripts/{script_id}/executions/{execution_id}', {
+                params: { path: { component_id: entityId, script_id: scriptId, execution_id: executionId } },
+                signal,
+            });
+    }
+}
+
+/**
+ * `action` is a plain string, not a union: the gateway forwards it verbatim to
+ * plugin backends, which may support control actions beyond stop and
+ * forced_termination.
+ */
+export function controlScriptExecution(
+    client: MedkitClient,
+    entityType: ScriptEntityType,
+    entityId: string,
+    scriptId: string,
+    executionId: string,
+    action: string
+) {
+    switch (entityType) {
+        case 'apps':
+            return client.PUT('/apps/{app_id}/scripts/{script_id}/executions/{execution_id}', {
+                params: { path: { app_id: entityId, script_id: scriptId, execution_id: executionId } },
+                body: { action },
+            });
+        case 'components':
+            return client.PUT('/components/{component_id}/scripts/{script_id}/executions/{execution_id}', {
+                params: { path: { component_id: entityId, script_id: scriptId, execution_id: executionId } },
+                body: { action },
+            });
+    }
+}
+
+export function deleteScriptExecution(
+    client: MedkitClient,
+    entityType: ScriptEntityType,
+    entityId: string,
+    scriptId: string,
+    executionId: string
+) {
+    switch (entityType) {
+        case 'apps':
+            return client.DELETE('/apps/{app_id}/scripts/{script_id}/executions/{execution_id}', {
+                params: { path: { app_id: entityId, script_id: scriptId, execution_id: executionId } },
+            });
+        case 'components':
+            return client.DELETE('/components/{component_id}/scripts/{script_id}/executions/{execution_id}', {
+                params: { path: { component_id: entityId, script_id: scriptId, execution_id: executionId } },
             });
     }
 }

--- a/src/lib/schema-utils.test.ts
+++ b/src/lib/schema-utils.test.ts
@@ -1,0 +1,92 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { convertJsonSchemaToTopicSchema } from './schema-utils';
+
+describe('convertJsonSchemaToTopicSchema', () => {
+    it('converts a flat object schema with typed properties', () => {
+        const result = convertJsonSchemaToTopicSchema({
+            type: 'object',
+            properties: {
+                verbose: { type: 'boolean' },
+                retries: { type: 'integer' },
+            },
+        });
+
+        expect(result).toEqual({
+            verbose: { type: 'bool' },
+            retries: { type: 'int32' },
+        });
+    });
+
+    it('converts nested object properties', () => {
+        const result = convertJsonSchemaToTopicSchema({
+            type: 'object',
+            properties: {
+                target: {
+                    type: 'object',
+                    properties: {
+                        host: { type: 'string' },
+                        port: { type: 'integer' },
+                    },
+                },
+            },
+        });
+
+        expect(result).toEqual({
+            target: {
+                type: 'object',
+                fields: {
+                    host: { type: 'string' },
+                    port: { type: 'int32' },
+                },
+            },
+        });
+    });
+
+    it('converts array properties through items', () => {
+        const result = convertJsonSchemaToTopicSchema({
+            type: 'object',
+            properties: {
+                tags: {
+                    type: 'array',
+                    items: { type: 'string' },
+                },
+            },
+        });
+
+        expect(result).toEqual({
+            tags: {
+                type: 'array',
+                items: { type: 'string' },
+            },
+        });
+    });
+
+    it('returns undefined for null and for a non-object input', () => {
+        expect(convertJsonSchemaToTopicSchema(null)).toBeUndefined();
+        expect(convertJsonSchemaToTopicSchema('not an object')).toBeUndefined();
+    });
+
+    it('passes a schema without properties through unchanged', () => {
+        // Documents today's pass-through behaviour: a schema with no `properties`
+        // key falls through to the final `return jsonSchema as TopicSchema` line
+        // unchanged, even though `{type: 'object'}` is not a valid TopicSchema
+        // (its "type" entry is a bare string, not a SchemaFieldType object).
+        const result = convertJsonSchemaToTopicSchema({ type: 'object' });
+
+        expect(result).toEqual({ type: 'object' });
+    });
+});

--- a/src/lib/script-language.test.ts
+++ b/src/lib/script-language.test.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { languageForFilename, hasExtension, templateFor } from './script-language';
+
+describe('languageForFilename', () => {
+    it('returns python for .py', () => {
+        expect(languageForFilename('check.py')).toBe('python');
+    });
+
+    it('returns shell for .sh and .bash', () => {
+        expect(languageForFilename('check.sh')).toBe('shell');
+        expect(languageForFilename('check.bash')).toBe('shell');
+    });
+
+    it('returns plain for an unknown extension and for no extension', () => {
+        expect(languageForFilename('check.exe')).toBe('plain');
+        expect(languageForFilename('check')).toBe('plain');
+    });
+
+    it('is case insensitive', () => {
+        expect(languageForFilename('Check.PY')).toBe('python');
+        expect(languageForFilename('Check.SH')).toBe('shell');
+        expect(languageForFilename('Check.BASH')).toBe('shell');
+    });
+});
+
+describe('hasExtension', () => {
+    it('accepts a name with a non-empty extension', () => {
+        expect(hasExtension('check.sh')).toBe(true);
+    });
+
+    it('rejects a name with no dot', () => {
+        expect(hasExtension('check')).toBe(false);
+    });
+
+    it('rejects a name ending in a dot', () => {
+        expect(hasExtension('check.')).toBe(false);
+    });
+
+    it('rejects an empty name', () => {
+        expect(hasExtension('')).toBe(false);
+    });
+
+    it('rejects a dotfile with no extension', () => {
+        expect(hasExtension('.bashrc')).toBe(false);
+    });
+});
+
+describe('templateFor', () => {
+    it('returns a python template for a .py name', () => {
+        const template = templateFor('check.py');
+        expect(template).toContain('sys.stdin');
+    });
+
+    it('returns a bash template otherwise', () => {
+        const template = templateFor('check.sh');
+        expect(template).toContain('cat');
+    });
+});

--- a/src/lib/script-language.test.ts
+++ b/src/lib/script-language.test.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { describe, it, expect } from 'vitest';
-import { languageForFilename, hasExtension, templateFor } from './script-language';
+import { languageForFilename, hasExtension, isPlainBasename, templateFor } from './script-language';
 
 describe('languageForFilename', () => {
     it('returns python for .py', () => {
@@ -56,6 +56,45 @@ describe('hasExtension', () => {
 
     it('rejects a dotfile with no extension', () => {
         expect(hasExtension('.bashrc')).toBe(false);
+    });
+
+    it('reads the extension from the last path segment only, not the whole string', () => {
+        // A dot in an earlier path segment (my.dir/check) must not be picked
+        // up as the extension of the file itself - `check` has none.
+        expect(hasExtension('my.dir/check')).toBe(false);
+        expect(hasExtension('my.dir/check.sh')).toBe(true);
+    });
+});
+
+describe('isPlainBasename', () => {
+    it('accepts an ordinary file name', () => {
+        expect(isPlainBasename('check.sh')).toBe(true);
+    });
+
+    it('rejects an empty name', () => {
+        expect(isPlainBasename('')).toBe(false);
+    });
+
+    it('rejects "." and ".."', () => {
+        expect(isPlainBasename('.')).toBe(false);
+        expect(isPlainBasename('..')).toBe(false);
+    });
+
+    it('rejects a forward-slash path traversal attempt', () => {
+        expect(isPlainBasename('../../etc/cron.d/evil.sh')).toBe(false);
+    });
+
+    it('rejects any name containing a forward slash, even without traversal', () => {
+        expect(isPlainBasename('my.dir/check')).toBe(false);
+        expect(isPlainBasename('scripts/check.sh')).toBe(false);
+    });
+
+    it('rejects a back-slash path', () => {
+        expect(isPlainBasename('..\\..\\windows\\evil.bat')).toBe(false);
+    });
+
+    it('accepts a dotfile-like name that is not "." or ".."', () => {
+        expect(isPlainBasename('.bashrc')).toBe(true);
     });
 });
 

--- a/src/lib/script-language.ts
+++ b/src/lib/script-language.ts
@@ -1,0 +1,78 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * The gateway picks the interpreter from the uploaded file's extension:
+ * `.py` runs under python3, `.bash` under bash, and everything else - including
+ * no extension at all - under sh. `languageForFilename` mirrors that split so
+ * the editor's syntax highlighting matches what will actually execute.
+ */
+export type ScriptLanguage = 'python' | 'shell' | 'plain';
+
+function extensionOf(filename: string): string {
+    const dot = filename.lastIndexOf('.');
+    if (dot <= 0 || dot === filename.length - 1) return '';
+    return filename.slice(dot + 1).toLowerCase();
+}
+
+export function languageForFilename(filename: string): ScriptLanguage {
+    const ext = extensionOf(filename);
+    if (ext === 'py') return 'python';
+    if (ext === 'sh' || ext === 'bash') return 'shell';
+    return 'plain';
+}
+
+/**
+ * True when `filename` has a non-empty extension after a non-leading dot.
+ * A leading dot alone (`.bashrc`) does not count: the gateway needs a real
+ * suffix to pick an interpreter, not a hidden-file marker.
+ */
+export function hasExtension(filename: string): boolean {
+    return extensionOf(filename) !== '';
+}
+
+const PYTHON_TEMPLATE = `#!/usr/bin/env python3
+import json
+import sys
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    params = json.loads(raw) if raw.strip() else {}
+    result = {"received": params}
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+`;
+
+const SHELL_TEMPLATE = `#!/bin/sh
+set -eu
+
+params=$(cat)
+
+printf '{"received": %s}\\n' "\${params:-null}"
+`;
+
+/**
+ * Starter content for write mode. Parameters entered in the Run form reach a
+ * script as JSON on stdin, never as argv, and the gateway discards stdout
+ * entirely when a script exits non-zero - so the template must read stdin,
+ * print JSON on stdout, and exit zero, or it teaches the wrong thing.
+ */
+export function templateFor(filename: string): string {
+    return languageForFilename(filename) === 'python' ? PYTHON_TEMPLATE : SHELL_TEMPLATE;
+}

--- a/src/lib/script-language.ts
+++ b/src/lib/script-language.ts
@@ -25,10 +25,35 @@
  */
 export type ScriptLanguage = 'python' | 'shell' | 'plain';
 
+/**
+ * Last path segment of `filename`. `extensionOf` must look here rather than
+ * at the whole string: a name like `my.dir/check` has a dot before the last
+ * separator but no extension at all, and reading the extension from the full
+ * string would report `dir/check` as one.
+ */
+function lastPathSegment(filename: string): string {
+    const separator = Math.max(filename.lastIndexOf('/'), filename.lastIndexOf('\\'));
+    return separator === -1 ? filename : filename.slice(separator + 1);
+}
+
 function extensionOf(filename: string): string {
-    const dot = filename.lastIndexOf('.');
-    if (dot <= 0 || dot === filename.length - 1) return '';
-    return filename.slice(dot + 1).toLowerCase();
+    const base = lastPathSegment(filename);
+    const dot = base.lastIndexOf('.');
+    if (dot <= 0 || dot === base.length - 1) return '';
+    return base.slice(dot + 1).toLowerCase();
+}
+
+/**
+ * True when `filename` is a plain basename: non-empty, containing no forward
+ * or back slash, and not `.` or `..`. Write mode puts this string verbatim
+ * into the multipart upload's filename field, which the gateway uses to name
+ * a file - and ultimately an executable script - on the robot; this repo
+ * must reject anything that looks like a path before it ever reaches that
+ * request, regardless of what the gateway itself does with it afterwards.
+ */
+export function isPlainBasename(filename: string): boolean {
+    if (filename === '' || filename === '.' || filename === '..') return false;
+    return !filename.includes('/') && !filename.includes('\\');
 }
 
 export function languageForFilename(filename: string): ScriptLanguage {
@@ -39,9 +64,11 @@ export function languageForFilename(filename: string): ScriptLanguage {
 }
 
 /**
- * True when `filename` has a non-empty extension after a non-leading dot.
- * A leading dot alone (`.bashrc`) does not count: the gateway needs a real
- * suffix to pick an interpreter, not a hidden-file marker.
+ * True when `filename` has a non-empty extension after a non-leading dot in
+ * its last path segment. A leading dot alone (`.bashrc`) does not count: the
+ * gateway needs a real suffix to pick an interpreter, not a hidden-file
+ * marker. Does not by itself guarantee `filename` is a safe upload name -
+ * pair with `isPlainBasename` for that.
  */
 export function hasExtension(filename: string): boolean {
     return extensionOf(filename) !== '';

--- a/src/lib/script-language.ts
+++ b/src/lib/script-language.ts
@@ -14,9 +14,14 @@
 
 /**
  * The gateway picks the interpreter from the uploaded file's extension:
- * `.py` runs under python3, `.bash` under bash, and everything else - including
- * no extension at all - under sh. `languageForFilename` mirrors that split so
- * the editor's syntax highlighting matches what will actually execute.
+ * `.py` runs under python3, `.bash` under bash, and everything else -
+ * including no extension at all - under sh. `languageForFilename` does not
+ * mirror that split one-to-one: `.sh` and `.bash` both highlight as `shell`,
+ * since both are shell syntax, but an unrecognised extension (or none)
+ * returns `plain` rather than guessing `shell` too. The file would still run
+ * under sh either way, but highlighting arbitrary, unrecognised content as
+ * shell would be wrong often enough to mislead - sh is just the gateway's
+ * fallback for "could be anything", not a signal that it looks like shell.
  */
 export type ScriptLanguage = 'python' | 'shell' | 'plain';
 

--- a/src/lib/scripts-polling.test.ts
+++ b/src/lib/scripts-polling.test.ts
@@ -1,0 +1,294 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { pollScriptExecutionsOnce, collectActiveExecutions } from './scripts-polling';
+import { SCRIPT_ERROR_CODE } from './scripts';
+import type { ScriptEntityType, ScriptExecutionRecord } from './types';
+
+// ---------------------------------------------------------------------------
+// Mock client factory - same shape as api-dispatch.test.ts
+// ---------------------------------------------------------------------------
+
+function createMockClient() {
+    return {
+        GET: vi.fn().mockResolvedValue({ data: { ok: true }, error: undefined }),
+        POST: vi.fn().mockResolvedValue({ data: { ok: true }, error: undefined }),
+        PUT: vi.fn().mockResolvedValue({ data: { ok: true }, error: undefined }),
+        DELETE: vi.fn().mockResolvedValue({ data: { ok: true }, error: undefined }),
+        streams: {},
+    };
+}
+
+type MockClient = ReturnType<typeof createMockClient>;
+type HistoryMap = Map<string, ScriptExecutionRecord[]>;
+
+function record(
+    id: string,
+    status = 'running',
+    entityType: ScriptEntityType = 'components',
+    entityId = 'ecu'
+): ScriptExecutionRecord {
+    return {
+        execution: { id, status },
+        scriptId: 'diag',
+        scriptName: 'diag',
+        entityType,
+        entityId,
+    };
+}
+
+describe('collectActiveExecutions', () => {
+    it('keeps only active, non-lost records across every key', () => {
+        const history: HistoryMap = new Map([
+            ['components/ecu', [record('e1', 'running'), record('e2', 'completed')]],
+            [
+                'apps/talker',
+                [
+                    { ...record('e3', 'prepared', 'apps', 'talker'), lost: true },
+                    record('e4', 'prepared', 'apps', 'talker'),
+                ],
+            ],
+        ]);
+
+        const active = collectActiveExecutions(history);
+
+        expect(active.map((r) => r.execution.id)).toEqual(['e1', 'e4']);
+    });
+});
+
+describe('pollScriptExecutionsOnce', () => {
+    let client: MockClient;
+    beforeEach(() => {
+        client = createMockClient();
+    });
+
+    it('returns null when no execution is active', async () => {
+        const history: HistoryMap = new Map([['components/ecu', [record('e1', 'completed')]]]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await pollScriptExecutionsOnce(client as any, history);
+
+        expect(result).toBeNull();
+        expect(client.GET).not.toHaveBeenCalled();
+    });
+
+    it('skips records already marked lost', async () => {
+        const lost = { ...record('e1', 'running'), lost: true };
+        const history: HistoryMap = new Map([['components/ecu', [lost]]]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await pollScriptExecutionsOnce(client as any, history);
+
+        expect(result).toBeNull();
+        expect(client.GET).not.toHaveBeenCalled();
+    });
+
+    it('queries every active execution once per call', async () => {
+        client.GET.mockResolvedValue({
+            data: { id: 'x', status: 'running' },
+            error: undefined,
+            response: { status: 200 },
+        });
+        const history: HistoryMap = new Map([
+            ['components/ecu', [record('e1', 'running'), record('e2', 'prepared')]],
+            ['apps/talker', [record('e3', 'running', 'apps', 'talker')]],
+        ]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await pollScriptExecutionsOnce(client as any, history);
+
+        expect(client.GET).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns the fresh execution payload as an outcome, without touching the input', async () => {
+        const fresh = { id: 'e1', status: 'completed', progress: 100 };
+        client.GET.mockResolvedValue({ data: fresh, error: undefined, response: { status: 200 } });
+        const original = record('e1', 'running');
+        const originalExecution = original.execution;
+        const history: HistoryMap = new Map([['components/ecu', [original]]]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await pollScriptExecutionsOnce(client as any, history);
+
+        expect(result).not.toBeNull();
+        expect(result).toHaveLength(1);
+        const outcome = result![0]!;
+        expect('lost' in outcome).toBe(false);
+        if (!('lost' in outcome)) {
+            expect(outcome.execution).toEqual(fresh);
+        }
+        // The caller re-derives the key from outcome.record, so it must be the
+        // same tracked record - not a copy.
+        expect(outcome.record).toBe(original);
+
+        // The input map and the original record must be untouched - the function must never mutate its arguments.
+        expect(history.get('components/ecu')![0]).toBe(original);
+        expect(original.execution).toBe(originalExecution);
+        expect(original.execution.status).toBe('running');
+    });
+
+    it('marks a record lost on a resource-not-found 404 and leaves the others untouched', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        client.GET.mockImplementation((_path: string, opts: any) => {
+            const execId = opts.params.path.execution_id as string;
+            if (execId === 'e1') {
+                return Promise.resolve({
+                    data: undefined,
+                    error: { message: 'Not found', error_code: SCRIPT_ERROR_CODE.resourceNotFound },
+                    response: { status: 404 },
+                });
+            }
+            return Promise.resolve({
+                data: { id: execId, status: 'prepared' },
+                error: undefined,
+                response: { status: 200 },
+            });
+        });
+        const r1 = record('e1', 'running');
+        const r2 = record('e2', 'running');
+        const history: HistoryMap = new Map([['components/ecu', [r1, r2]]]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await pollScriptExecutionsOnce(client as any, history);
+
+        expect(result).toHaveLength(2);
+        const outcome1 = result!.find((o) => o.record.execution.id === 'e1')!;
+        const outcome2 = result!.find((o) => o.record.execution.id === 'e2')!;
+        expect('lost' in outcome1 && outcome1.lost).toBe(true);
+        expect('lost' in outcome2).toBe(false);
+        if (!('lost' in outcome2)) {
+            expect(outcome2.execution.status).toBe('prepared');
+        }
+
+        // The input map and the original records must be untouched.
+        expect(history.get('components/ecu')).toEqual([r1, r2]);
+        expect(r1.lost).toBeUndefined();
+        expect(r2.execution.status).toBe('running');
+    });
+
+    it('omits the record on a 404 whose error_code is entity-not-found, since the entity may reappear', async () => {
+        client.GET.mockResolvedValue({
+            data: undefined,
+            error: { message: 'Entity not found', error_code: SCRIPT_ERROR_CODE.entityNotFound },
+            response: { status: 404 },
+        });
+        const original = record('e1', 'running');
+        const history: HistoryMap = new Map([['components/ecu', [original]]]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await pollScriptExecutionsOnce(client as any, history);
+
+        expect(result).toEqual([]);
+        // Not marked lost and not evicted from the caller's perspective: the
+        // original record is untouched, unlike the resource-not-found case above.
+        expect(history.get('components/ecu')![0]).toBe(original);
+        expect(original.lost).toBeUndefined();
+    });
+
+    it('omits the record from outcomes when the request fails with 500', async () => {
+        client.GET.mockResolvedValue({
+            data: undefined,
+            error: { message: 'Internal Server Error' },
+            response: { status: 500 },
+        });
+        const original = record('e1', 'running');
+        const history: HistoryMap = new Map([['components/ecu', [original]]]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await pollScriptExecutionsOnce(client as any, history);
+
+        expect(result).toEqual([]);
+        // The input map and the original record must be untouched.
+        expect(history.get('components/ecu')![0]).toBe(original);
+        expect(original.execution.status).toBe('running');
+    });
+
+    it('uses the entity type and id carried by the record', async () => {
+        client.GET.mockResolvedValue({
+            data: { id: 'e1', status: 'running' },
+            error: undefined,
+            response: { status: 200 },
+        });
+        const appRecord = record('e1', 'running', 'apps', 'talker');
+        const history: HistoryMap = new Map([['apps/talker', [appRecord]]]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await pollScriptExecutionsOnce(client as any, history);
+
+        expect(client.GET).toHaveBeenCalledTimes(1);
+        const [path, opts] = client.GET.mock.calls[0]!;
+        expect(path).toBe('/apps/{app_id}/scripts/{script_id}/executions/{execution_id}');
+        expect(opts.params.path).toEqual({ app_id: 'talker', script_id: 'diag', execution_id: 'e1' });
+    });
+
+    it('returns independent outcomes for records tracked under different keys', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        client.GET.mockImplementation((_path: string, opts: any) => {
+            const execId = opts.params.path.execution_id as string;
+            if (execId === 'e1') {
+                return Promise.resolve({
+                    data: undefined,
+                    error: { message: 'gone', error_code: SCRIPT_ERROR_CODE.resourceNotFound },
+                    response: { status: 404 },
+                });
+            }
+            return Promise.resolve({
+                data: { id: execId, status: 'completed' },
+                error: undefined,
+                response: { status: 200 },
+            });
+        });
+        const r1 = record('e1', 'running', 'components', 'ecu');
+        const r2 = record('e2', 'prepared', 'apps', 'talker');
+        const history: HistoryMap = new Map([
+            ['components/ecu', [r1]],
+            ['apps/talker', [r2]],
+        ]);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const result = await pollScriptExecutionsOnce(client as any, history);
+
+        expect(result).toHaveLength(2);
+        const outcome1 = result!.find((o) => o.record === r1)!;
+        const outcome2 = result!.find((o) => o.record === r2)!;
+        expect('lost' in outcome1 && outcome1.lost).toBe(true);
+        expect('lost' in outcome2).toBe(false);
+        if (!('lost' in outcome2)) {
+            expect(outcome2.execution.status).toBe('completed');
+        }
+
+        // The input map and the original records must be untouched.
+        expect(history.get('components/ecu')).toEqual([r1]);
+        expect(history.get('apps/talker')).toEqual([r2]);
+        expect(r1.lost).toBeUndefined();
+        expect(r2.execution.status).toBe('prepared');
+    });
+
+    it('returns null when the abort signal is already aborted', async () => {
+        const controller = new AbortController();
+        controller.abort();
+        const history: HistoryMap = new Map([['components/ecu', [record('e1', 'running')]]]);
+
+        const result = await pollScriptExecutionsOnce(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            client as any,
+            history,
+            { signal: controller.signal }
+        );
+
+        expect(result).toBeNull();
+        expect(client.GET).not.toHaveBeenCalled();
+    });
+});

--- a/src/lib/scripts-polling.ts
+++ b/src/lib/scripts-polling.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Polling cycle for tracked script executions, kept out of the zustand store
+ * so it can be unit tested directly (this repo has no pattern for testing
+ * store actions). The store wraps this in a setInterval.
+ *
+ * This module only issues the requests and reports what happened per record;
+ * it never folds results onto a history map itself. Folding requires
+ * re-reading the store's state after the await (the map may have changed
+ * while requests were in flight - a sibling action may have added, removed,
+ * or already updated a record), so that responsibility belongs to the
+ * caller, not to a function that only ever sees a single snapshot.
+ */
+
+import type { MedkitClient } from '@selfpatch/ros2-medkit-client-ts';
+import { getScriptExecution } from './api-dispatch';
+import { isActiveScriptStatus, scriptErrorCode, SCRIPT_ERROR_CODE } from './scripts';
+import type { ScriptExecution, ScriptExecutionRecord } from './types';
+
+type HistoryMap = Map<string, ScriptExecutionRecord[]>;
+
+export function collectActiveExecutions(history: HistoryMap): ScriptExecutionRecord[] {
+    const active: ScriptExecutionRecord[] = [];
+    for (const records of history.values()) {
+        for (const record of records) {
+            if (!record.lost && isActiveScriptStatus(record.execution.status)) active.push(record);
+        }
+    }
+    return active;
+}
+
+/** Outcome of polling a single tracked execution. */
+export type ScriptPollOutcome =
+    | { record: ScriptExecutionRecord; execution: ScriptExecution }
+    | { record: ScriptExecutionRecord; lost: true };
+
+/**
+ * One polling cycle. Returns the outcomes of the requests made, or null when
+ * there was nothing to do (so the caller can stop the interval). A record
+ * whose request failed with anything other than `resource-not-found` (the
+ * script or execution itself is gone) is simply omitted from the result -
+ * the caller keeps whatever it already has for it. In particular
+ * `entity-not-found` - the entity is momentarily absent, which happens under
+ * runtime discovery when a node restarts - must not evict the record, since
+ * the entity can reappear on the next tick.
+ */
+export async function pollScriptExecutionsOnce(
+    client: MedkitClient,
+    history: HistoryMap,
+    options: { signal?: AbortSignal } = {}
+): Promise<ScriptPollOutcome[] | null> {
+    if (options.signal?.aborted) return null;
+
+    const active = collectActiveExecutions(history);
+    if (active.length === 0) return null;
+
+    const results = await Promise.all(
+        active.map(async (record): Promise<ScriptPollOutcome | null> => {
+            try {
+                const { data, error } = await getScriptExecution(
+                    client,
+                    record.entityType,
+                    record.entityId,
+                    record.scriptId,
+                    record.execution.id,
+                    options.signal
+                );
+                if (error) {
+                    return scriptErrorCode(error) === SCRIPT_ERROR_CODE.resourceNotFound
+                        ? { record, lost: true as const }
+                        : null;
+                }
+                return data ? { record, execution: data as ScriptExecution } : null;
+            } catch (err) {
+                console.error('[scriptPolling] failed:', err);
+                return null;
+            }
+        })
+    );
+
+    return results.filter((result): result is ScriptPollOutcome => result !== null);
+}

--- a/src/lib/scripts.test.ts
+++ b/src/lib/scripts.test.ts
@@ -27,6 +27,10 @@ import {
     markExecutionLost,
     removeExecutionRecord,
     MAX_EXECUTION_HISTORY,
+    toScriptExecution,
+    isPlainJsonObject,
+    SCRIPT_OUTPUT_HEAD_CHARS,
+    SCRIPT_OUTPUT_TAIL_CHARS,
 } from './scripts';
 import type { ScriptExecution, ScriptExecutionRecord } from './types';
 
@@ -107,6 +111,56 @@ describe('scriptErrorMessage', () => {
     });
 });
 
+describe('toScriptExecution', () => {
+    it('returns the value unchanged when it has a string id and status', () => {
+        const value = { id: 'e1', status: 'running' };
+        expect(toScriptExecution(value)).toBe(value);
+    });
+
+    it('throws a ScriptsApiError for undefined data (an empty 2xx body, e.g. a 202)', () => {
+        expect(() => toScriptExecution(undefined)).toThrow(ScriptsApiError);
+    });
+
+    it('throws for a value missing status', () => {
+        expect(() => toScriptExecution({ id: 'e1' })).toThrow(ScriptsApiError);
+    });
+
+    it('throws for a value missing id', () => {
+        expect(() => toScriptExecution({ status: 'running' })).toThrow(ScriptsApiError);
+    });
+
+    it('throws for a non-object value', () => {
+        expect(() => toScriptExecution('e1')).toThrow(ScriptsApiError);
+        expect(() => toScriptExecution(null)).toThrow(ScriptsApiError);
+    });
+});
+
+describe('isPlainJsonObject', () => {
+    it('accepts a plain object', () => {
+        expect(isPlainJsonObject({ verbose: true })).toBe(true);
+    });
+
+    it('accepts an empty object', () => {
+        expect(isPlainJsonObject({})).toBe(true);
+    });
+
+    it('rejects an array', () => {
+        expect(isPlainJsonObject([1, 2])).toBe(false);
+    });
+
+    it('rejects null', () => {
+        expect(isPlainJsonObject(null)).toBe(false);
+    });
+
+    it('rejects a string', () => {
+        expect(isPlainJsonObject('hello')).toBe(false);
+    });
+
+    it('rejects a number', () => {
+        expect(isPlainJsonObject(42)).toBe(false);
+    });
+});
+
 describe('scriptOutput', () => {
     it('returns null when parameters is null', () => {
         const execution: ScriptExecution = { id: 'e1', status: 'completed', parameters: null };
@@ -130,6 +184,37 @@ describe('scriptOutput', () => {
             parameters: { stdout: 'hi', exit_code: 0 },
         };
         expect(scriptOutput(execution)).toEqual({ kind: 'json', value: { stdout: 'hi', exit_code: 0 } });
+    });
+
+    it('leaves stdout under the cap untouched', () => {
+        const text = 'x'.repeat(SCRIPT_OUTPUT_HEAD_CHARS + SCRIPT_OUTPUT_TAIL_CHARS);
+        const execution: ScriptExecution = { id: 'e1', status: 'completed', parameters: { stdout: text } };
+        expect(scriptOutput(execution)).toEqual({ kind: 'stdout', text });
+    });
+
+    it('truncates stdout over the cap, keeping a head and a tail behind a marker', () => {
+        // A few megabytes is entirely gateway-controlled and would otherwise
+        // sit whole in a single DOM text node - the max-height CSS on the
+        // <pre> only limits the scrollable box, not the node's size.
+        const head = 'A'.repeat(SCRIPT_OUTPUT_HEAD_CHARS);
+        const middle = 'M'.repeat(50_000);
+        const tail = 'Z'.repeat(SCRIPT_OUTPUT_TAIL_CHARS);
+        const execution: ScriptExecution = {
+            id: 'e1',
+            status: 'completed',
+            parameters: { stdout: head + middle + tail },
+        };
+
+        const output = scriptOutput(execution);
+        expect(output?.kind).toBe('stdout');
+        const text = (output as { kind: 'stdout'; text: string }).text;
+
+        expect(text.startsWith(head)).toBe(true);
+        expect(text.endsWith(tail)).toBe(true);
+        expect(text).toContain('truncated');
+        expect(text).toContain('50000');
+        // Bounded well below the original size - not just "smaller".
+        expect(text.length).toBeLessThan(SCRIPT_OUTPUT_HEAD_CHARS + SCRIPT_OUTPUT_TAIL_CHARS + 200);
     });
 
     it('returns a json entry for a non-object payload', () => {
@@ -228,6 +313,22 @@ describe('execution history reducers', () => {
         const arr = next.get('components/ecu')!;
         expect(arr).toHaveLength(MAX_EXECUTION_HISTORY);
         expect(arr.some((r) => r.execution.id === 'running-1')).toBe(true);
+    });
+
+    it('can return more than MAX_EXECUTION_HISTORY records when active executions alone exceed the cap', () => {
+        // The cap only ever applies to *inactive* records - it is not a
+        // guarantee on the list's overall length. With more active records
+        // than MAX_EXECUTION_HISTORY, none of them may be dropped (their ids
+        // could never be recovered - the gateway has no endpoint to list
+        // executions), so the result is longer than the cap.
+        const running = Array.from({ length: MAX_EXECUTION_HISTORY + 5 }, (_, i) => record(`r${i}`, 'running'));
+        const initial: Map<string, ScriptExecutionRecord[]> = new Map([['components/ecu', running]]);
+
+        const next = upsertExecutionRecord(initial, 'components/ecu', record('r-new', 'running'));
+
+        const arr = next.get('components/ecu')!;
+        expect(arr.length).toBeGreaterThan(MAX_EXECUTION_HISTORY);
+        expect(arr).toHaveLength(running.length + 1);
     });
 
     it('marks a single record as lost without touching its neighbours', () => {

--- a/src/lib/scripts.test.ts
+++ b/src/lib/scripts.test.ts
@@ -1,0 +1,288 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import {
+    ScriptsApiError,
+    toScriptsApiError,
+    scriptErrorMessage,
+    ACTIVE_SCRIPT_STATUSES,
+    isActiveScriptStatus,
+    scriptEntityKey,
+    SCRIPT_ERROR_CODE,
+    scriptOutput,
+    scriptFailure,
+    upsertExecutionRecord,
+    markExecutionLost,
+    removeExecutionRecord,
+    MAX_EXECUTION_HISTORY,
+} from './scripts';
+import type { ScriptExecution, ScriptExecutionRecord } from './types';
+
+function record(id: string, status = 'running', scriptId = 'diag'): ScriptExecutionRecord {
+    return {
+        execution: { id, status },
+        scriptId,
+        scriptName: scriptId,
+        entityType: 'components',
+        entityId: 'ecu',
+    };
+}
+
+describe('isActiveScriptStatus', () => {
+    it('treats prepared and running as active', () => {
+        expect(isActiveScriptStatus('prepared')).toBe(true);
+        expect(isActiveScriptStatus('running')).toBe(true);
+        expect(ACTIVE_SCRIPT_STATUSES).toEqual(['prepared', 'running']);
+    });
+
+    it('treats terminal and unknown statuses as inactive', () => {
+        expect(isActiveScriptStatus('completed')).toBe(false);
+        expect(isActiveScriptStatus('failed')).toBe(false);
+        expect(isActiveScriptStatus('terminated')).toBe(false);
+        expect(isActiveScriptStatus('aborted-by-plugin')).toBe(false);
+        expect(isActiveScriptStatus('')).toBe(false);
+    });
+});
+
+describe('scriptEntityKey', () => {
+    it('joins entity type and id', () => {
+        expect(scriptEntityKey('apps', 'talker')).toBe('apps/talker');
+    });
+});
+
+describe('toScriptsApiError', () => {
+    it('takes the status from the response and the code from the body', () => {
+        const err = toScriptsApiError({ error_code: SCRIPT_ERROR_CODE.managed, message: 'Managed script' }, 409);
+        expect(err).toBeInstanceOf(ScriptsApiError);
+        expect(err.status).toBe(409);
+        expect(err.errorCode).toBe('x-medkit-managed-script');
+        expect(err.message).toBe('Managed script');
+    });
+
+    it('falls back to HTTP <status> when the body carries no message', () => {
+        const err = toScriptsApiError({}, 502);
+        expect(err.status).toBe(502);
+        expect(err.errorCode).toBe('');
+        expect(err.message).toBe('HTTP 502');
+    });
+
+    it('falls back for a non-object error value', () => {
+        const err = toScriptsApiError('boom', 502);
+        expect(err.status).toBe(502);
+        expect(err.errorCode).toBe('');
+        expect(err.message).toBe('HTTP 502');
+    });
+});
+
+describe('scriptErrorMessage', () => {
+    it('uses the gateway message when present', () => {
+        const err = new ScriptsApiError('Managed script', 409, SCRIPT_ERROR_CODE.managed);
+        expect(scriptErrorMessage(err, 'fallback')).toBe('Managed script');
+    });
+
+    it('uses the fallback for an empty message', () => {
+        const err = new ScriptsApiError('', 500, '');
+        expect(scriptErrorMessage(err, 'fallback')).toBe('fallback');
+    });
+
+    it('uses the fallback for a non-error value', () => {
+        expect(scriptErrorMessage(undefined, 'fallback')).toBe('fallback');
+    });
+
+    it('uses the fallback for a bare network Error', () => {
+        const err = new TypeError('Failed to fetch');
+        expect(scriptErrorMessage(err, 'fallback')).toBe('fallback');
+    });
+});
+
+describe('scriptOutput', () => {
+    it('returns null when parameters is null', () => {
+        const execution: ScriptExecution = { id: 'e1', status: 'completed', parameters: null };
+        expect(scriptOutput(execution)).toBeNull();
+    });
+
+    it('returns null for an empty object', () => {
+        const execution: ScriptExecution = { id: 'e1', status: 'completed', parameters: {} };
+        expect(scriptOutput(execution)).toBeNull();
+    });
+
+    it('returns a stdout entry when stdout is the only key', () => {
+        const execution: ScriptExecution = { id: 'e1', status: 'completed', parameters: { stdout: 'hi' } };
+        expect(scriptOutput(execution)).toEqual({ kind: 'stdout', text: 'hi' });
+    });
+
+    it('returns a json entry when stdout appears with other keys', () => {
+        const execution: ScriptExecution = {
+            id: 'e1',
+            status: 'completed',
+            parameters: { stdout: 'hi', exit_code: 0 },
+        };
+        expect(scriptOutput(execution)).toEqual({ kind: 'json', value: { stdout: 'hi', exit_code: 0 } });
+    });
+
+    it('returns a json entry for a non-object payload', () => {
+        expect(scriptOutput({ id: 'e1', status: 'completed', parameters: 42 })).toEqual({
+            kind: 'json',
+            value: 42,
+        });
+        expect(scriptOutput({ id: 'e1', status: 'completed', parameters: [1, 2] })).toEqual({
+            kind: 'json',
+            value: [1, 2],
+        });
+        expect(scriptOutput({ id: 'e1', status: 'completed', parameters: 'text' })).toEqual({
+            kind: 'json',
+            value: 'text',
+        });
+    });
+});
+
+describe('scriptFailure', () => {
+    it('returns null when error is null', () => {
+        const execution: ScriptExecution = { id: 'e1', status: 'failed', error: null };
+        expect(scriptFailure(execution)).toBeNull();
+    });
+
+    it('extracts message and exit code from a failed execution', () => {
+        const execution: ScriptExecution = {
+            id: 'e1',
+            status: 'failed',
+            error: { message: 'Script exited with an error', exit_code: 3 },
+        };
+        expect(scriptFailure(execution)).toEqual({ message: 'Script exited with an error', exitCode: 3 });
+    });
+
+    it('returns exitCode null for a stop or timeout error', () => {
+        const execution: ScriptExecution = {
+            id: 'e1',
+            status: 'terminated',
+            error: { message: 'Execution stopped by user' },
+        };
+        expect(scriptFailure(execution)).toEqual({ message: 'Execution stopped by user', exitCode: null });
+    });
+
+    it('returns null when error is not an object', () => {
+        const execution: ScriptExecution = { id: 'e1', status: 'failed', error: 'boom' };
+        expect(scriptFailure(execution)).toBeNull();
+    });
+});
+
+describe('execution history reducers', () => {
+    it('prepends a new record and returns a new map and a new array', () => {
+        const existing = record('e1');
+        const initial: Map<string, ScriptExecutionRecord[]> = new Map([['components/ecu', [existing]]]);
+        const incoming = record('e2');
+
+        const next = upsertExecutionRecord(initial, 'components/ecu', incoming);
+
+        expect(next).not.toBe(initial);
+        expect(next.get('components/ecu')).not.toBe(initial.get('components/ecu'));
+        expect(next.get('components/ecu')).toEqual([incoming, existing]);
+    });
+
+    it('replaces an existing record in place, preserving order', () => {
+        const r1 = record('e1');
+        const r2 = record('e2');
+        const initial: Map<string, ScriptExecutionRecord[]> = new Map([['components/ecu', [r1, r2]]]);
+        const updated: ScriptExecutionRecord = { ...r1, execution: { ...r1.execution, status: 'completed' } };
+
+        const next = upsertExecutionRecord(initial, 'components/ecu', updated);
+
+        expect(next.get('components/ecu')).toEqual([updated, r2]);
+    });
+
+    it('trims history to MAX_EXECUTION_HISTORY, dropping the oldest inactive record', () => {
+        // records[0] is the newest, the last element is the oldest.
+        const records = Array.from({ length: MAX_EXECUTION_HISTORY }, (_, i) =>
+            record(`c${MAX_EXECUTION_HISTORY - 1 - i}`, 'completed')
+        );
+        const initial: Map<string, ScriptExecutionRecord[]> = new Map([['components/ecu', records]]);
+
+        const next = upsertExecutionRecord(initial, 'components/ecu', record('c-new', 'completed'));
+
+        const arr = next.get('components/ecu')!;
+        expect(arr).toHaveLength(MAX_EXECUTION_HISTORY);
+        expect(arr[0]!.execution.id).toBe('c-new');
+        expect(arr.some((r) => r.execution.id === 'c0')).toBe(false);
+        expect(arr.some((r) => r.execution.id === 'c1')).toBe(true);
+    });
+
+    it('never drops a record that is still active when trimming', () => {
+        const completed = Array.from({ length: 25 }, (_, i) => record(`c${i}`, 'completed'));
+        const running = record('running-1', 'running');
+        const initial: Map<string, ScriptExecutionRecord[]> = new Map([['components/ecu', [...completed, running]]]);
+
+        const next = upsertExecutionRecord(initial, 'components/ecu', record('c-new', 'completed'));
+
+        const arr = next.get('components/ecu')!;
+        expect(arr).toHaveLength(MAX_EXECUTION_HISTORY);
+        expect(arr.some((r) => r.execution.id === 'running-1')).toBe(true);
+    });
+
+    it('marks a single record as lost without touching its neighbours', () => {
+        const r1 = record('e1');
+        const r2 = record('e2');
+        const initial: Map<string, ScriptExecutionRecord[]> = new Map([['components/ecu', [r1, r2]]]);
+
+        const next = markExecutionLost(initial, 'components/ecu', 'e1');
+
+        expect(next).not.toBe(initial);
+        const arr = next.get('components/ecu')!;
+        expect(arr).not.toBe(initial.get('components/ecu'));
+        expect(arr[0]).toEqual({ ...r1, lost: true });
+        expect(arr[1]).toBe(r2);
+    });
+
+    it('returns the same map when marking an unknown key', () => {
+        const initial: Map<string, ScriptExecutionRecord[]> = new Map([['components/ecu', [record('e1')]]]);
+
+        const next = markExecutionLost(initial, 'apps/other', 'e1');
+
+        expect(next).toBe(initial);
+    });
+
+    it('removes only the target record', () => {
+        const r1 = record('e1');
+        const r2 = record('e2');
+        const initial: Map<string, ScriptExecutionRecord[]> = new Map([['components/ecu', [r1, r2]]]);
+
+        const next = removeExecutionRecord(initial, 'components/ecu', 'e1');
+
+        expect(next).not.toBe(initial);
+        const arr = next.get('components/ecu')!;
+        expect(arr).not.toBe(initial.get('components/ecu'));
+        expect(arr).toEqual([r2]);
+    });
+
+    it('drops the key entirely when the last record is removed', () => {
+        const initial: Map<string, ScriptExecutionRecord[]> = new Map([['components/ecu', [record('e1')]]]);
+
+        const next = removeExecutionRecord(initial, 'components/ecu', 'e1');
+
+        expect(next.has('components/ecu')).toBe(false);
+    });
+
+    it('keeps other entities untouched', () => {
+        const ecuRecords = [record('e1')];
+        const otherRecords = [record('e2', 'running', 'other')];
+        const initial: Map<string, ScriptExecutionRecord[]> = new Map([
+            ['components/ecu', ecuRecords],
+            ['apps/talker', otherRecords],
+        ]);
+
+        const next = removeExecutionRecord(initial, 'components/ecu', 'e1');
+
+        expect(next.get('apps/talker')).toBe(otherRecords);
+    });
+});

--- a/src/lib/scripts.ts
+++ b/src/lib/scripts.ts
@@ -74,6 +74,34 @@ export function scriptErrorMessage(err: unknown, fallback: string): string {
 }
 
 /**
+ * Validate an openapi-fetch success payload as a usable `ScriptExecution`
+ * before it enters the store. `data as ScriptExecution` is a cast, not a
+ * check: openapi-fetch yields `undefined` data for an empty body on a 2xx
+ * response (legitimate for a 202), and an unchecked cast would let that - or
+ * any other malformed payload - become a record whose `execution` is
+ * unusable. The very next read of `record.execution.status` (the next
+ * polling tick, or the card's render) would then throw on something that is
+ * not actually broken, just not yet reflected correctly.
+ */
+export function toScriptExecution(data: unknown): ScriptExecution {
+    if (isRecord(data) && typeof data.id === 'string' && typeof data.status === 'string') {
+        return data as ScriptExecution;
+    }
+    throw new ScriptsApiError('The gateway returned an unusable response for this execution', 0, '');
+}
+
+/**
+ * True for a plain JSON object: excludes arrays, `null`, and primitives.
+ * `JSON.parse` accepts all of those too, so a bare cast to
+ * `Record<string, unknown>` would let `[1,2]`, `"hello"`, `42` and `null`
+ * all pass through as script parameters and earn a gateway 400 instead of
+ * the inline error the parameter field already knows how to show.
+ */
+export function isPlainJsonObject(value: unknown): value is Record<string, unknown> {
+    return isRecord(value) && !Array.isArray(value);
+}
+
+/**
  * Statuses worth polling. Deliberately a white list: `status` is a free-form
  * string on the wire (plugin backends return their own values) and a black list
  * of terminal statuses would poll an unknown status forever.
@@ -91,6 +119,27 @@ export function scriptEntityKey(entityType: ScriptEntityType, entityId: string):
 export type ScriptOutput = { kind: 'stdout'; text: string } | { kind: 'json'; value: unknown };
 
 /**
+ * Characters of stdout kept from the start and the end of an oversized dump.
+ * The content is entirely gateway-controlled and rendered into a single
+ * `<pre>` text node whose CSS `max-height` only limits the scrollable box,
+ * not the size of the DOM node itself - a script that prints a few megabytes
+ * would otherwise sit there in full, and up to MAX_EXECUTION_HISTORY of
+ * them can be held per entity at once.
+ */
+export const SCRIPT_OUTPUT_HEAD_CHARS = 4000;
+export const SCRIPT_OUTPUT_TAIL_CHARS = 2000;
+const SCRIPT_OUTPUT_MAX_CHARS = SCRIPT_OUTPUT_HEAD_CHARS + SCRIPT_OUTPUT_TAIL_CHARS;
+
+/** Keeps a head and a tail of `text`, with an explicit marker showing what was cut. */
+function truncateOutput(text: string): string {
+    if (text.length <= SCRIPT_OUTPUT_MAX_CHARS) return text;
+    const head = text.slice(0, SCRIPT_OUTPUT_HEAD_CHARS);
+    const tail = text.slice(text.length - SCRIPT_OUTPUT_TAIL_CHARS);
+    const omitted = text.length - SCRIPT_OUTPUT_HEAD_CHARS - SCRIPT_OUTPUT_TAIL_CHARS;
+    return `${head}\n\n... [truncated ${omitted} characters] ...\n\n${tail}`;
+}
+
+/**
  * Narrow `ScriptExecution.parameters` (typed `unknown | null`, because the spec
  * declares it as free-form). The gateway parses stdout as JSON and falls back to
  * `{stdout: "..."}` when it is not JSON, so the stdout-only shape gets rendered
@@ -103,7 +152,7 @@ export function scriptOutput(execution: ScriptExecution): ScriptOutput | null {
         const keys = Object.keys(value);
         if (keys.length === 0) return null;
         if (keys.length === 1 && keys[0] === 'stdout' && typeof value.stdout === 'string') {
-            return { kind: 'stdout', text: value.stdout };
+            return { kind: 'stdout', text: truncateOutput(value.stdout) };
         }
     }
     return { kind: 'json', value };
@@ -130,9 +179,12 @@ export const MAX_EXECUTION_HISTORY = 20;
 type HistoryMap = Map<string, ScriptExecutionRecord[]>;
 
 /**
- * Trim to MAX_EXECUTION_HISTORY, dropping the oldest *inactive* records first.
- * Dropping a running execution would orphan the process: the gateway has no
- * endpoint to list executions, so its id could never be recovered.
+ * Caps the *inactive* records at MAX_EXECUTION_HISTORY, dropping the oldest
+ * ones first - not the list as a whole, which can end up longer than that
+ * when active executions push it over the cap. Dropping a running execution
+ * would orphan the process: the gateway has no endpoint to list executions,
+ * so its id could never be recovered. Every currently active record is kept
+ * regardless of how many there are.
  */
 function trimHistory(records: ScriptExecutionRecord[]): ScriptExecutionRecord[] {
     if (records.length <= MAX_EXECUTION_HISTORY) return records;

--- a/src/lib/scripts.ts
+++ b/src/lib/scripts.ts
@@ -1,0 +1,177 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import type { ScriptEntityType, ScriptExecution, ScriptExecutionRecord } from './types';
+
+/** Wire values of GenericError.error_code used by the scripts endpoints. */
+export const SCRIPT_ERROR_CODE = {
+    notImplemented: 'not-implemented',
+    entityNotFound: 'entity-not-found',
+    resourceNotFound: 'resource-not-found',
+    invalidRequest: 'invalid-request',
+    invalidParameter: 'invalid-parameter',
+    managed: 'x-medkit-managed-script',
+    running: 'x-medkit-script-running',
+    notRunning: 'x-medkit-script-not-running',
+    alreadyExists: 'x-medkit-script-already-exists',
+    tooLarge: 'x-medkit-script-too-large',
+    concurrencyLimit: 'x-medkit-concurrency-limit',
+} as const;
+
+/**
+ * Error carrying the gateway status and wire error code. The `throw new
+ * Error(message)` pattern used elsewhere in the store drops both, and the
+ * scripts UI needs them to tell 409-managed from 409-running.
+ */
+export class ScriptsApiError extends Error {
+    readonly status: number;
+    readonly errorCode: string;
+
+    constructor(message: string, status: number, errorCode: string) {
+        super(message);
+        this.name = 'ScriptsApiError';
+        this.status = status;
+        this.errorCode = errorCode;
+    }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+/** Extract GenericError.error_code from an openapi-fetch error body of unknown shape. */
+export function scriptErrorCode(error: unknown): string {
+    return isRecord(error) && typeof error.error_code === 'string' ? error.error_code : '';
+}
+
+/**
+ * Build a ScriptsApiError from an openapi-fetch error body and the response
+ * status. GenericError has no `status` field, so the status always comes from
+ * the response.
+ */
+export function toScriptsApiError(error: unknown, status: number): ScriptsApiError {
+    if (isRecord(error)) {
+        const message = typeof error.message === 'string' && error.message ? error.message : `HTTP ${status}`;
+        return new ScriptsApiError(message, status, scriptErrorCode(error));
+    }
+    return new ScriptsApiError(`HTTP ${status}`, status, '');
+}
+
+/** Message for the user: gateway text when present, otherwise the caller's fallback. */
+export function scriptErrorMessage(err: unknown, fallback: string): string {
+    return err instanceof ScriptsApiError && err.message ? err.message : fallback;
+}
+
+/**
+ * Statuses worth polling. Deliberately a white list: `status` is a free-form
+ * string on the wire (plugin backends return their own values) and a black list
+ * of terminal statuses would poll an unknown status forever.
+ */
+export const ACTIVE_SCRIPT_STATUSES = ['prepared', 'running'] as const;
+
+export function isActiveScriptStatus(status: string): boolean {
+    return (ACTIVE_SCRIPT_STATUSES as readonly string[]).includes(status);
+}
+
+export function scriptEntityKey(entityType: ScriptEntityType, entityId: string): string {
+    return `${entityType}/${entityId}`;
+}
+
+export type ScriptOutput = { kind: 'stdout'; text: string } | { kind: 'json'; value: unknown };
+
+/**
+ * Narrow `ScriptExecution.parameters` (typed `unknown | null`, because the spec
+ * declares it as free-form). The gateway parses stdout as JSON and falls back to
+ * `{stdout: "..."}` when it is not JSON, so the stdout-only shape gets rendered
+ * as text and everything else as JSON.
+ */
+export function scriptOutput(execution: ScriptExecution): ScriptOutput | null {
+    const value = execution.parameters;
+    if (value === null || value === undefined) return null;
+    if (isRecord(value)) {
+        const keys = Object.keys(value);
+        if (keys.length === 0) return null;
+        if (keys.length === 1 && keys[0] === 'stdout' && typeof value.stdout === 'string') {
+            return { kind: 'stdout', text: value.stdout };
+        }
+    }
+    return { kind: 'json', value };
+}
+
+export interface ScriptFailure {
+    message: string;
+    /** Present only for a non-zero exit; stop, force kill and timeout carry no exit code. */
+    exitCode: number | null;
+}
+
+/** Narrow `ScriptExecution.error` (typed `unknown | null`). */
+export function scriptFailure(execution: ScriptExecution): ScriptFailure | null {
+    const value = execution.error;
+    if (!isRecord(value)) return null;
+    const message = typeof value.message === 'string' ? value.message : '';
+    if (!message) return null;
+    return { message, exitCode: typeof value.exit_code === 'number' ? value.exit_code : null };
+}
+
+/** Upper bound on tracked executions per entity; a record can hold a full stdout dump. */
+export const MAX_EXECUTION_HISTORY = 20;
+
+type HistoryMap = Map<string, ScriptExecutionRecord[]>;
+
+/**
+ * Trim to MAX_EXECUTION_HISTORY, dropping the oldest *inactive* records first.
+ * Dropping a running execution would orphan the process: the gateway has no
+ * endpoint to list executions, so its id could never be recovered.
+ */
+function trimHistory(records: ScriptExecutionRecord[]): ScriptExecutionRecord[] {
+    if (records.length <= MAX_EXECUTION_HISTORY) return records;
+    const active = records.filter((r) => isActiveScriptStatus(r.execution.status));
+    const inactive = records.filter((r) => !isActiveScriptStatus(r.execution.status));
+    const keepInactive = inactive.slice(0, Math.max(0, MAX_EXECUTION_HISTORY - active.length));
+    return records.filter((r) => active.includes(r) || keepInactive.includes(r));
+}
+
+/**
+ * Insert or replace a record. Always returns a new Map and a new array for the
+ * touched key so zustand's reference comparison re-renders subscribers.
+ */
+export function upsertExecutionRecord(map: HistoryMap, key: string, record: ScriptExecutionRecord): HistoryMap {
+    const current = map.get(key) ?? [];
+    const index = current.findIndex((r) => r.execution.id === record.execution.id);
+    const next = index >= 0 ? current.map((r, i) => (i === index ? record : r)) : [record, ...current];
+    const result = new Map(map);
+    result.set(key, trimHistory(next));
+    return result;
+}
+
+export function markExecutionLost(map: HistoryMap, key: string, executionId: string): HistoryMap {
+    const current = map.get(key);
+    if (!current || !current.some((r) => r.execution.id === executionId)) return map;
+    const result = new Map(map);
+    result.set(
+        key,
+        current.map((r) => (r.execution.id === executionId ? { ...r, lost: true } : r))
+    );
+    return result;
+}
+
+export function removeExecutionRecord(map: HistoryMap, key: string, executionId: string): HistoryMap {
+    const current = map.get(key);
+    if (!current) return map;
+    const next = current.filter((r) => r.execution.id !== executionId);
+    const result = new Map(map);
+    if (next.length === 0) result.delete(key);
+    else result.set(key, next);
+    return result;
+}

--- a/src/lib/store-connect.test.ts
+++ b/src/lib/store-connect.test.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { MedkitClient } from '@selfpatch/ros2-medkit-client-ts';
+
+// -----------------------------------------------------------------------------
+// connect() must not let the scripts-capability probe (GET /) stall entity
+// loading: a gateway that answers /health and then hangs on GET / would
+// otherwise leave the UI showing "connected" over an empty tree for the
+// full 5s timeout, on every connect. createMedkitClient is mocked so the
+// test can hold GET / pending indefinitely while asserting that loading the
+// root entities does not wait for it.
+// -----------------------------------------------------------------------------
+
+vi.mock('@selfpatch/ros2-medkit-client-ts', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@selfpatch/ros2-medkit-client-ts')>();
+    return {
+        ...actual,
+        createMedkitClient: vi.fn(),
+    };
+});
+
+import { useAppStore } from './store';
+import { createMedkitClient } from '@selfpatch/ros2-medkit-client-ts';
+
+describe('connect', () => {
+    const originalLoadRootEntities = useAppStore.getState().loadRootEntities;
+    const originalSubscribeFaultStream = useAppStore.getState().subscribeFaultStream;
+
+    beforeEach(() => {
+        useAppStore.setState({ client: null, isConnected: false, scriptsSupported: false });
+    });
+
+    afterEach(() => {
+        useAppStore.getState().stopScriptPolling();
+        useAppStore.setState({
+            client: null,
+            isConnected: false,
+            scriptsSupported: false,
+            loadRootEntities: originalLoadRootEntities,
+            subscribeFaultStream: originalSubscribeFaultStream,
+        });
+        vi.restoreAllMocks();
+    });
+
+    it('loads root entities without waiting for the capability probe to resolve', async () => {
+        let resolveCaps: (() => void) | undefined;
+        const capsPromise = new Promise((resolve) => {
+            resolveCaps = () => resolve({ data: { capabilities: { scripts: true } } });
+        });
+
+        const mockGet = vi.fn((path: string) => {
+            if (path === '/health') return Promise.resolve({ error: undefined });
+            if (path === '/') return capsPromise; // Never resolves until resolveCaps() is called.
+            return Promise.resolve({ data: undefined });
+        });
+
+        vi.mocked(createMedkitClient).mockReturnValue({ GET: mockGet } as unknown as MedkitClient);
+
+        const loadRootEntities = vi.fn().mockResolvedValue(undefined);
+        const subscribeFaultStream = vi.fn();
+        useAppStore.setState({ loadRootEntities, subscribeFaultStream });
+
+        // Race connect() against a short real-timer delay instead of relying
+        // on vitest's global test timeout: if connect() awaited the capability
+        // probe first (the bug), it would still be pending when the timer
+        // fires, since resolveCaps() is deliberately never called before this
+        // point.
+        const raceResult = await Promise.race([
+            useAppStore
+                .getState()
+                .connect('http://gateway.local')
+                .then((result) => ({ outcome: 'connected' as const, result })),
+            new Promise((resolve) => setTimeout(() => resolve({ outcome: 'timeout' as const }), 100)),
+        ]);
+
+        expect(raceResult).toEqual({ outcome: 'connected', result: true });
+        expect(loadRootEntities).toHaveBeenCalledTimes(1);
+        expect(subscribeFaultStream).toHaveBeenCalledTimes(1);
+
+        // The probe itself must still land once it resolves - the client-
+        // identity guard makes this late result safe, not meaningless.
+        resolveCaps?.();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(useAppStore.getState().scriptsSupported).toBe(true);
+    });
+});

--- a/src/lib/store-scripts.test.ts
+++ b/src/lib/store-scripts.test.ts
@@ -1,0 +1,103 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useAppStore } from './store';
+import { SCRIPT_ERROR_CODE } from './scripts';
+import type { MedkitClient } from '@selfpatch/ros2-medkit-client-ts';
+import type { ScriptExecutionRecord } from './types';
+
+// -----------------------------------------------------------------------------
+// refreshScriptExecution is a store action, not a pure helper, so it cannot be
+// exercised through store-helpers.test.ts. It is tested here against the real
+// store (setState/getState) rather than through a mock, since the bug this
+// covers - the `lost` flag never clearing, and any 404 (not just
+// resource-not-found) setting it - lives in the wiring between the fetch
+// result and the state update, not in a function that could be pulled out
+// in isolation.
+// -----------------------------------------------------------------------------
+
+function makeRecord(overrides: Partial<ScriptExecutionRecord> = {}): ScriptExecutionRecord {
+    return {
+        execution: { id: 'e1', status: 'completed' },
+        scriptId: 'diag',
+        scriptName: 'diag',
+        entityType: 'components',
+        entityId: 'ecu',
+        ...overrides,
+    };
+}
+
+function makeClient(response: unknown): MedkitClient {
+    return { GET: vi.fn().mockResolvedValue(response) } as unknown as MedkitClient;
+}
+
+describe('refreshScriptExecution', () => {
+    beforeEach(() => {
+        useAppStore.getState().stopScriptPolling();
+        useAppStore.setState({ client: null, scriptExecutions: new Map(), scriptPollingIntervalId: null });
+    });
+
+    afterEach(() => {
+        useAppStore.getState().stopScriptPolling();
+        useAppStore.setState({ client: null, scriptExecutions: new Map(), scriptPollingIntervalId: null });
+    });
+
+    it('clears a stale lost flag once the gateway answers successfully', async () => {
+        const client = makeClient({
+            data: { id: 'e1', status: 'completed' },
+            error: undefined,
+            response: { status: 200 },
+        });
+        useAppStore.setState({
+            client,
+            scriptExecutions: new Map([['components/ecu', [makeRecord({ lost: true })]]]),
+        });
+
+        await useAppStore.getState().refreshScriptExecution('components', 'ecu', 'diag', 'e1');
+
+        const updated = useAppStore.getState().scriptExecutions.get('components/ecu')?.[0];
+        expect(updated?.lost).toBe(false);
+    });
+
+    it('leaves an untracked record alone on entity-not-found, since the entity may reappear', async () => {
+        const client = makeClient({
+            data: undefined,
+            error: { message: 'Entity not found', error_code: SCRIPT_ERROR_CODE.entityNotFound },
+            response: { status: 404 },
+        });
+        const original = makeRecord();
+        useAppStore.setState({ client, scriptExecutions: new Map([['components/ecu', [original]]]) });
+
+        await useAppStore.getState().refreshScriptExecution('components', 'ecu', 'diag', 'e1');
+
+        const record = useAppStore.getState().scriptExecutions.get('components/ecu')?.[0];
+        expect(record?.lost).toBeUndefined();
+    });
+
+    it('marks a record lost when the 404 is resource-not-found', async () => {
+        const client = makeClient({
+            data: undefined,
+            error: { message: 'gone', error_code: SCRIPT_ERROR_CODE.resourceNotFound },
+            response: { status: 404 },
+        });
+        const original = makeRecord();
+        useAppStore.setState({ client, scriptExecutions: new Map([['components/ecu', [original]]]) });
+
+        await useAppStore.getState().refreshScriptExecution('components', 'ecu', 'diag', 'e1');
+
+        const record = useAppStore.getState().scriptExecutions.get('components/ecu')?.[0];
+        expect(record?.lost).toBe(true);
+    });
+});

--- a/src/lib/store-scripts.test.ts
+++ b/src/lib/store-scripts.test.ts
@@ -14,18 +14,18 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useAppStore } from './store';
-import { SCRIPT_ERROR_CODE } from './scripts';
+import { SCRIPT_ERROR_CODE, ScriptsApiError } from './scripts';
 import type { MedkitClient } from '@selfpatch/ros2-medkit-client-ts';
-import type { ScriptExecutionRecord } from './types';
+import type { ScriptExecutionRecord, ScriptMetadata } from './types';
 
 // -----------------------------------------------------------------------------
-// refreshScriptExecution is a store action, not a pure helper, so it cannot be
-// exercised through store-helpers.test.ts. It is tested here against the real
-// store (setState/getState) rather than through a mock, since the bug this
-// covers - the `lost` flag never clearing, and any 404 (not just
-// resource-not-found) setting it - lives in the wiring between the fetch
-// result and the state update, not in a function that could be pulled out
-// in isolation.
+// These script store actions are not pure helpers, so they cannot be
+// exercised through store-helpers.test.ts. They are tested here against the
+// real store (setState/getState) rather than through a mock, since the bugs
+// covered - the `lost` flag never clearing, any 404 (not just
+// resource-not-found) setting it, an unchecked cast letting an unusable
+// payload into the store - live in the wiring between the fetch result and
+// the state update, not in a function that could be pulled out in isolation.
 // -----------------------------------------------------------------------------
 
 function makeRecord(overrides: Partial<ScriptExecutionRecord> = {}): ScriptExecutionRecord {
@@ -39,23 +39,38 @@ function makeRecord(overrides: Partial<ScriptExecutionRecord> = {}): ScriptExecu
     };
 }
 
-function makeClient(response: unknown): MedkitClient {
-    return { GET: vi.fn().mockResolvedValue(response) } as unknown as MedkitClient;
+function makeScript(overrides: Partial<ScriptMetadata> = {}): ScriptMetadata {
+    return { id: 'diag', name: 'Diagnostics', ...overrides };
 }
 
+/**
+ * `GET` always gets a harmless default response, even when the test is
+ * really exercising POST or PUT: a successful start/stop can make
+ * startScriptPolling create a real interval, and if that interval happens to
+ * fire before the test's own cleanup runs, it must not hit an undefined
+ * `client.GET`.
+ */
+function makeClient(method: 'GET' | 'POST' | 'PUT', response: unknown): MedkitClient {
+    const client: Record<string, unknown> = {
+        GET: vi.fn().mockResolvedValue({ data: undefined, error: undefined, response: { status: 200 } }),
+    };
+    client[method] = vi.fn().mockResolvedValue(response);
+    return client as unknown as MedkitClient;
+}
+
+beforeEach(() => {
+    useAppStore.getState().stopScriptPolling();
+    useAppStore.setState({ client: null, scriptExecutions: new Map(), scriptPollingIntervalId: null });
+});
+
+afterEach(() => {
+    useAppStore.getState().stopScriptPolling();
+    useAppStore.setState({ client: null, scriptExecutions: new Map(), scriptPollingIntervalId: null });
+});
+
 describe('refreshScriptExecution', () => {
-    beforeEach(() => {
-        useAppStore.getState().stopScriptPolling();
-        useAppStore.setState({ client: null, scriptExecutions: new Map(), scriptPollingIntervalId: null });
-    });
-
-    afterEach(() => {
-        useAppStore.getState().stopScriptPolling();
-        useAppStore.setState({ client: null, scriptExecutions: new Map(), scriptPollingIntervalId: null });
-    });
-
     it('clears a stale lost flag once the gateway answers successfully', async () => {
-        const client = makeClient({
+        const client = makeClient('GET', {
             data: { id: 'e1', status: 'completed' },
             error: undefined,
             response: { status: 200 },
@@ -71,8 +86,8 @@ describe('refreshScriptExecution', () => {
         expect(updated?.lost).toBe(false);
     });
 
-    it('leaves an untracked record alone on entity-not-found, since the entity may reappear', async () => {
-        const client = makeClient({
+    it('leaves an untracked record alone on entity-not-found, since the entity may reappear, but still surfaces the failure', async () => {
+        const client = makeClient('GET', {
             data: undefined,
             error: { message: 'Entity not found', error_code: SCRIPT_ERROR_CODE.entityNotFound },
             response: { status: 404 },
@@ -80,14 +95,19 @@ describe('refreshScriptExecution', () => {
         const original = makeRecord();
         useAppStore.setState({ client, scriptExecutions: new Map([['components/ecu', [original]]]) });
 
-        await useAppStore.getState().refreshScriptExecution('components', 'ecu', 'diag', 'e1');
+        // Not the "gone" case (resource-not-found) - this must reach the
+        // caller so the card's "Failed to refresh" toast can fire, instead
+        // of being swallowed the way it used to be.
+        await expect(useAppStore.getState().refreshScriptExecution('components', 'ecu', 'diag', 'e1')).rejects.toThrow(
+            ScriptsApiError
+        );
 
         const record = useAppStore.getState().scriptExecutions.get('components/ecu')?.[0];
         expect(record?.lost).toBeUndefined();
     });
 
-    it('marks a record lost when the 404 is resource-not-found', async () => {
-        const client = makeClient({
+    it('marks a record lost when the 404 is resource-not-found, without throwing', async () => {
+        const client = makeClient('GET', {
             data: undefined,
             error: { message: 'gone', error_code: SCRIPT_ERROR_CODE.resourceNotFound },
             response: { status: 404 },
@@ -99,5 +119,104 @@ describe('refreshScriptExecution', () => {
 
         const record = useAppStore.getState().scriptExecutions.get('components/ecu')?.[0];
         expect(record?.lost).toBe(true);
+    });
+
+    it('rethrows a generic gateway error instead of swallowing it', async () => {
+        const client = makeClient('GET', {
+            data: undefined,
+            error: { message: 'Internal error', error_code: '' },
+            response: { status: 500 },
+        });
+        useAppStore.setState({ client, scriptExecutions: new Map([['components/ecu', [makeRecord()]]]) });
+
+        await expect(useAppStore.getState().refreshScriptExecution('components', 'ecu', 'diag', 'e1')).rejects.toThrow(
+            ScriptsApiError
+        );
+    });
+
+    it('throws instead of storing an unusable execution when the gateway returns no body', async () => {
+        // openapi-fetch yields undefined data for an empty body on a 2xx
+        // response - legitimate for a 202. `data as ScriptExecution` used to
+        // let that through unchecked.
+        const client = makeClient('GET', { data: undefined, error: undefined, response: { status: 202 } });
+        const original = makeRecord();
+        useAppStore.setState({ client, scriptExecutions: new Map([['components/ecu', [original]]]) });
+
+        await expect(useAppStore.getState().refreshScriptExecution('components', 'ecu', 'diag', 'e1')).rejects.toThrow(
+            ScriptsApiError
+        );
+
+        // The existing record must be untouched by the rejected payload.
+        expect(useAppStore.getState().scriptExecutions.get('components/ecu')?.[0]).toEqual(original);
+    });
+
+    it('throws when not connected', async () => {
+        useAppStore.setState({ client: null });
+        await expect(useAppStore.getState().refreshScriptExecution('components', 'ecu', 'diag', 'e1')).rejects.toThrow(
+            ScriptsApiError
+        );
+    });
+});
+
+describe('startScriptExecutionAction', () => {
+    it('throws instead of storing an unusable execution when the gateway returns no body', async () => {
+        const client = makeClient('POST', { data: undefined, error: undefined, response: { status: 202 } });
+        useAppStore.setState({ client });
+
+        await expect(
+            useAppStore
+                .getState()
+                .startScriptExecutionAction('components', 'ecu', makeScript(), { execution_type: 'now' })
+        ).rejects.toThrow(ScriptsApiError);
+
+        // The map must stay empty - not hold a record whose `execution` is
+        // undefined, which would throw the next time anything reads
+        // record.execution.status (collectActiveExecutions, on the very
+        // next polling tick, in particular).
+        expect(useAppStore.getState().scriptExecutions.get('components/ecu')).toBeUndefined();
+        expect(() => useAppStore.getState().startScriptPolling()).not.toThrow();
+    });
+
+    it('stores the execution when the gateway returns a usable payload', async () => {
+        const client = makeClient('POST', {
+            data: { id: 'e1', status: 'running' },
+            error: undefined,
+            response: { status: 200 },
+        });
+        useAppStore.setState({ client });
+
+        await useAppStore.getState().startScriptExecutionAction('components', 'ecu', makeScript(), {
+            execution_type: 'now',
+        });
+
+        expect(useAppStore.getState().scriptExecutions.get('components/ecu')?.[0]?.execution.status).toBe('running');
+    });
+});
+
+describe('stopScriptExecution', () => {
+    it('throws instead of corrupting the record when the gateway returns no body', async () => {
+        const client = makeClient('PUT', { data: undefined, error: undefined, response: { status: 202 } });
+        const original = makeRecord();
+        useAppStore.setState({ client, scriptExecutions: new Map([['components/ecu', [original]]]) });
+
+        await expect(
+            useAppStore.getState().stopScriptExecution('components', 'ecu', 'diag', 'e1', 'stop')
+        ).rejects.toThrow(ScriptsApiError);
+
+        expect(useAppStore.getState().scriptExecutions.get('components/ecu')?.[0]).toEqual(original);
+    });
+
+    it('updates the record when the gateway returns a usable payload', async () => {
+        const client = makeClient('PUT', {
+            data: { id: 'e1', status: 'terminated' },
+            error: undefined,
+            response: { status: 200 },
+        });
+        const original = makeRecord();
+        useAppStore.setState({ client, scriptExecutions: new Map([['components/ecu', [original]]]) });
+
+        await useAppStore.getState().stopScriptExecution('components', 'ecu', 'diag', 'e1', 'stop');
+
+        expect(useAppStore.getState().scriptExecutions.get('components/ecu')?.[0]?.execution.status).toBe('terminated');
     });
 });

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -16,6 +16,14 @@ import type {
     App,
     VersionInfo,
     SovdFunction,
+    ScriptEntityType,
+    ScriptExecution,
+    ScriptExecutionRecord,
+    ScriptMetadata,
+    ScriptsFetchResult,
+    ScriptUploadMetadata,
+    ScriptUploadResponse,
+    StartScriptExecutionRequest,
 } from './types';
 import { createMedkitClient, normalizeBaseUrl, type MedkitClient } from '@selfpatch/ros2-medkit-client-ts';
 import type { SovdResourceEntityType } from './types';
@@ -47,11 +55,30 @@ import {
     getEntityLogs,
     getEntityLogsConfiguration,
     putEntityLogsConfiguration,
+    getEntityScripts,
+    uploadEntityScript,
+    deleteEntityScript,
+    startScriptExecution,
+    getScriptExecution,
+    controlScriptExecution,
+    deleteScriptExecution,
 } from './api-dispatch';
 import type { LogCollection, LogsConfiguration, LogsFetchResult, LogsQueryParams } from './log-types';
+import { collectActiveExecutions, pollScriptExecutionsOnce } from './scripts-polling';
+import {
+    ScriptsApiError,
+    toScriptsApiError,
+    scriptErrorCode,
+    scriptEntityKey,
+    upsertExecutionRecord,
+    markExecutionLost,
+    removeExecutionRecord,
+    SCRIPT_ERROR_CODE,
+} from './scripts';
 
 const STORAGE_KEY = 'ros2_medkit_web_ui_server_url';
 const EXECUTION_POLL_INTERVAL_MS = 1000;
+const SCRIPT_POLL_INTERVAL_MS = 1000;
 const EXECUTION_CLEANUP_AFTER_MS = 5 * 60 * 1000; // 5 minutes
 
 export type TreeViewMode = 'logical' | 'functional';
@@ -102,6 +129,13 @@ export interface AppState {
     activeExecutions: Map<string, TrackedExecution>; // executionId -> tracked execution with metadata
     autoRefreshExecutions: boolean; // flag for auto-refresh polling
     executionPollingIntervalId: ReturnType<typeof setInterval> | null; // polling interval ID
+
+    // Scripts state (diagnostic scripts uploaded per app/component). In-memory
+    // only: the gateway has no endpoint listing executions, so history does
+    // not survive a reload.
+    scriptsSupported: boolean; // gateway capability from GET /
+    scriptExecutions: Map<string, ScriptExecutionRecord[]>; // scriptEntityKey(entityType, entityId) -> history
+    scriptPollingIntervalId: ReturnType<typeof setInterval> | null; // polling interval ID
 
     // Faults state (diagnostic trouble codes)
     faults: Fault[];
@@ -156,6 +190,47 @@ export interface AppState {
     setAutoRefreshExecutions: (enabled: boolean) => void;
     startExecutionPolling: () => void;
     stopExecutionPolling: () => void;
+
+    // Scripts actions
+    fetchEntityScripts: (
+        entityType: ScriptEntityType,
+        entityId: string,
+        signal?: AbortSignal
+    ) => Promise<ScriptsFetchResult>;
+    uploadScript: (
+        entityType: ScriptEntityType,
+        entityId: string,
+        file: File,
+        metadata?: ScriptUploadMetadata
+    ) => Promise<ScriptUploadResponse>;
+    deleteScript: (entityType: ScriptEntityType, entityId: string, scriptId: string) => Promise<void>;
+    startScriptExecutionAction: (
+        entityType: ScriptEntityType,
+        entityId: string,
+        script: ScriptMetadata,
+        request: StartScriptExecutionRequest
+    ) => Promise<void>;
+    stopScriptExecution: (
+        entityType: ScriptEntityType,
+        entityId: string,
+        scriptId: string,
+        executionId: string,
+        action: string
+    ) => Promise<void>;
+    removeScriptExecution: (
+        entityType: ScriptEntityType,
+        entityId: string,
+        scriptId: string,
+        executionId: string
+    ) => Promise<void>;
+    refreshScriptExecution: (
+        entityType: ScriptEntityType,
+        entityId: string,
+        scriptId: string,
+        executionId: string
+    ) => Promise<void>;
+    startScriptPolling: () => void;
+    stopScriptPolling: () => void;
 
     // Faults actions
     fetchFaults: () => Promise<void>;
@@ -860,6 +935,11 @@ export const useAppStore = create<AppState>()(
             autoRefreshExecutions: true,
             executionPollingIntervalId: null,
 
+            // Scripts state
+            scriptsSupported: false,
+            scriptExecutions: new Map(),
+            scriptPollingIntervalId: null,
+
             // Faults state
             faults: [],
             isLoadingFaults: false,
@@ -897,6 +977,32 @@ export const useAppStore = create<AppState>()(
                         client,
                     });
 
+                    // A reconnect must not carry executions of the previous gateway:
+                    // ids would 404 and show up as ghost records under matching entity ids.
+                    get().stopScriptPolling();
+                    set({ scriptExecutions: new Map(), scriptsSupported: false });
+
+                    // Scripts tab visibility follows the gateway capability. Guarded by
+                    // the same 5s timeout as the health check so a slow gateway cannot
+                    // stall entity loading.
+                    try {
+                        const capsController = new AbortController();
+                        const capsTimeout = setTimeout(() => capsController.abort(), 5000);
+                        const { data: root } = await client
+                            .GET('/', { signal: capsController.signal })
+                            .finally(() => clearTimeout(capsTimeout));
+                        // A disconnect or a newer connect() may have completed while this
+                        // probe was in flight; a stale result must not clobber the state
+                        // of the session that is current now.
+                        if (get().client === client) {
+                            set({ scriptsSupported: root?.capabilities.scripts === true });
+                        }
+                    } catch {
+                        if (get().client === client) {
+                            set({ scriptsSupported: false });
+                        }
+                    }
+
                     // Load root entities after successful connection
                     await get().loadRootEntities();
 
@@ -925,6 +1031,9 @@ export const useAppStore = create<AppState>()(
                 // Stop execution polling
                 get().stopExecutionPolling();
 
+                // Stop script execution polling
+                get().stopScriptPolling();
+
                 // Unsubscribe from fault stream
                 get().unsubscribeFaultStream();
 
@@ -940,6 +1049,8 @@ export const useAppStore = create<AppState>()(
                     selectedPath: null,
                     selectedEntity: null,
                     activeExecutions: new Map(),
+                    scriptsSupported: false,
+                    scriptExecutions: new Map(),
                 });
             },
 
@@ -1875,6 +1986,254 @@ export const useAppStore = create<AppState>()(
                     clearInterval(executionPollingIntervalId);
                     set({ executionPollingIntervalId: null });
                 }
+            },
+
+            // ===========================================================================
+            // SCRIPTS ACTIONS (diagnostic scripts uploaded per app/component)
+            // ===========================================================================
+
+            fetchEntityScripts: async (entityType: ScriptEntityType, entityId: string, signal?: AbortSignal) => {
+                const { client } = get();
+                if (!client) return { items: [], errorStatus: -1 };
+                try {
+                    const { data, error, response } = await getEntityScripts(client, entityType, entityId, signal);
+                    if (error) {
+                        return { items: [], errorStatus: response?.status ?? -1 };
+                    }
+                    return { items: data ? unwrapItems<ScriptMetadata>(data) : [] };
+                } catch (err) {
+                    if ((err as { name?: string }).name === 'AbortError') throw err;
+                    console.error('[store] fetchEntityScripts failed', err);
+                    return { items: [], errorStatus: -1 };
+                }
+            },
+
+            uploadScript: async (
+                entityType: ScriptEntityType,
+                entityId: string,
+                file: File,
+                metadata?: ScriptUploadMetadata
+            ) => {
+                const { client } = get();
+                if (!client) throw new ScriptsApiError('Not connected', 0, '');
+
+                const form = new FormData();
+                form.append('file', file, file.name);
+                if (metadata?.name || metadata?.description) {
+                    form.append('metadata', JSON.stringify(metadata));
+                }
+
+                const { data, error, response } = await uploadEntityScript(client, entityType, entityId, form);
+                if (error) throw toScriptsApiError(error, response?.status ?? 0);
+                return data as ScriptUploadResponse;
+            },
+
+            deleteScript: async (entityType: ScriptEntityType, entityId: string, scriptId: string) => {
+                const { client } = get();
+                if (!client) throw new ScriptsApiError('Not connected', 0, '');
+
+                const { error, response } = await deleteEntityScript(client, entityType, entityId, scriptId);
+                if (error) throw toScriptsApiError(error, response?.status ?? 0);
+            },
+
+            startScriptExecutionAction: async (
+                entityType: ScriptEntityType,
+                entityId: string,
+                script: ScriptMetadata,
+                request: StartScriptExecutionRequest
+            ) => {
+                const { client } = get();
+                if (!client) throw new ScriptsApiError('Not connected', 0, '');
+
+                const { data, error, response } = await startScriptExecution(
+                    client,
+                    entityType,
+                    entityId,
+                    script.id,
+                    request
+                );
+                if (error) throw toScriptsApiError(error, response?.status ?? 0);
+
+                const key = scriptEntityKey(entityType, entityId);
+                const record: ScriptExecutionRecord = {
+                    execution: data as ScriptExecution,
+                    scriptId: script.id,
+                    scriptName: script.name,
+                    entityType,
+                    entityId,
+                };
+                set({ scriptExecutions: upsertExecutionRecord(get().scriptExecutions, key, record) });
+                get().startScriptPolling();
+            },
+
+            stopScriptExecution: async (
+                entityType: ScriptEntityType,
+                entityId: string,
+                scriptId: string,
+                executionId: string,
+                action: string
+            ) => {
+                const { client } = get();
+                if (!client) throw new ScriptsApiError('Not connected', 0, '');
+
+                const { data, error, response } = await controlScriptExecution(
+                    client,
+                    entityType,
+                    entityId,
+                    scriptId,
+                    executionId,
+                    action
+                );
+                if (error) throw toScriptsApiError(error, response?.status ?? 0);
+
+                const key = scriptEntityKey(entityType, entityId);
+                const existing = get()
+                    .scriptExecutions.get(key)
+                    ?.find((r) => r.execution.id === executionId);
+                if (existing) {
+                    const record: ScriptExecutionRecord = { ...existing, execution: data as ScriptExecution };
+                    set({ scriptExecutions: upsertExecutionRecord(get().scriptExecutions, key, record) });
+                    get().startScriptPolling();
+                }
+            },
+
+            removeScriptExecution: async (
+                entityType: ScriptEntityType,
+                entityId: string,
+                scriptId: string,
+                executionId: string
+            ) => {
+                const { client } = get();
+                if (!client) throw new ScriptsApiError('Not connected', 0, '');
+
+                const { error, response } = await deleteScriptExecution(
+                    client,
+                    entityType,
+                    entityId,
+                    scriptId,
+                    executionId
+                );
+                // A 404 means the gateway already forgot this execution - treat as success.
+                if (error && response?.status !== 404) throw toScriptsApiError(error, response?.status ?? 0);
+
+                const key = scriptEntityKey(entityType, entityId);
+                set({ scriptExecutions: removeExecutionRecord(get().scriptExecutions, key, executionId) });
+            },
+
+            refreshScriptExecution: async (
+                entityType: ScriptEntityType,
+                entityId: string,
+                scriptId: string,
+                executionId: string
+            ) => {
+                const { client } = get();
+                if (!client) return;
+
+                const key = scriptEntityKey(entityType, entityId);
+                try {
+                    const { data, error } = await getScriptExecution(
+                        client,
+                        entityType,
+                        entityId,
+                        scriptId,
+                        executionId
+                    );
+                    if (error) {
+                        // Only resource-not-found means the execution itself is gone.
+                        // entity-not-found means the entity is momentarily absent (a
+                        // node restarting under runtime discovery, for example) and
+                        // must not evict a record Refresh is meant to rescue.
+                        if (scriptErrorCode(error) === SCRIPT_ERROR_CODE.resourceNotFound) {
+                            set({ scriptExecutions: markExecutionLost(get().scriptExecutions, key, executionId) });
+                        }
+                        return;
+                    }
+                    if (!data) return;
+
+                    const existing = get()
+                        .scriptExecutions.get(key)
+                        ?.find((r) => r.execution.id === executionId);
+                    if (existing) {
+                        // Clear `lost`: a successful refresh means the gateway answered,
+                        // so this is exactly the rescue path a lost record needs.
+                        const record: ScriptExecutionRecord = {
+                            ...existing,
+                            execution: data as ScriptExecution,
+                            lost: false,
+                        };
+                        set({ scriptExecutions: upsertExecutionRecord(get().scriptExecutions, key, record) });
+                        get().startScriptPolling();
+                    }
+                } catch (err) {
+                    console.error('[store] refreshScriptExecution failed', err);
+                }
+            },
+
+            startScriptPolling: () => {
+                const { scriptPollingIntervalId, client } = get();
+                if (scriptPollingIntervalId || !client) return;
+                if (collectActiveExecutions(get().scriptExecutions).length === 0) return;
+
+                let inFlight = false;
+                const intervalId = setInterval(async () => {
+                    const currentClient = get().client;
+                    if (!currentClient) {
+                        get().stopScriptPolling();
+                        return;
+                    }
+                    // Skip the tick while the tab is hidden, but keep the interval
+                    // running so returning to the tab resumes polling by itself.
+                    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+                    // Never let two cycles overlap: on a slow link the responses would
+                    // arrive out of order and an old "running" could overwrite a fresh
+                    // terminal status, freezing the card forever.
+                    if (inFlight) return;
+
+                    inFlight = true;
+                    try {
+                        const outcomes = await pollScriptExecutionsOnce(currentClient, get().scriptExecutions);
+                        if (outcomes === null) {
+                            get().stopScriptPolling();
+                            return;
+                        }
+                        // The client may have changed while the cycle was in flight
+                        // (disconnect or reconnect); dropping the result keeps the
+                        // fresh session clean.
+                        if (get().client !== currentClient) return;
+
+                        // Fold onto state read AFTER the await, not the snapshot the cycle
+                        // started with: a sibling action (start/stop/remove) may have
+                        // written to scriptExecutions while the requests were in flight,
+                        // and that write must not be discarded.
+                        let next = get().scriptExecutions;
+                        for (const outcome of outcomes) {
+                            const key = scriptEntityKey(outcome.record.entityType, outcome.record.entityId);
+                            const stillTracked = next
+                                .get(key)
+                                ?.some((r) => r.execution.id === outcome.record.execution.id);
+                            // If the user removed the record mid-cycle, the tick must not resurrect it.
+                            if (!stillTracked) continue;
+                            next =
+                                'lost' in outcome
+                                    ? markExecutionLost(next, key, outcome.record.execution.id)
+                                    : upsertExecutionRecord(next, key, {
+                                          ...outcome.record,
+                                          execution: outcome.execution,
+                                      });
+                        }
+                        if (next !== get().scriptExecutions) set({ scriptExecutions: next });
+                    } finally {
+                        inFlight = false;
+                    }
+                }, SCRIPT_POLL_INTERVAL_MS);
+
+                set({ scriptPollingIntervalId: intervalId });
+            },
+
+            stopScriptPolling: () => {
+                const { scriptPollingIntervalId } = get();
+                if (scriptPollingIntervalId) clearInterval(scriptPollingIntervalId);
+                set({ scriptPollingIntervalId: null });
             },
 
             // ===========================================================================

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -17,7 +17,6 @@ import type {
     VersionInfo,
     SovdFunction,
     ScriptEntityType,
-    ScriptExecution,
     ScriptExecutionRecord,
     ScriptMetadata,
     ScriptsFetchResult,
@@ -73,6 +72,7 @@ import {
     upsertExecutionRecord,
     markExecutionLost,
     removeExecutionRecord,
+    toScriptExecution,
     SCRIPT_ERROR_CODE,
 } from './scripts';
 
@@ -982,26 +982,29 @@ export const useAppStore = create<AppState>()(
                     get().stopScriptPolling();
                     set({ scriptExecutions: new Map(), scriptsSupported: false });
 
-                    // Scripts tab visibility follows the gateway capability. Guarded by
-                    // the same 5s timeout as the health check so a slow gateway cannot
-                    // stall entity loading.
-                    try {
-                        const capsController = new AbortController();
-                        const capsTimeout = setTimeout(() => capsController.abort(), 5000);
-                        const { data: root } = await client
-                            .GET('/', { signal: capsController.signal })
-                            .finally(() => clearTimeout(capsTimeout));
-                        // A disconnect or a newer connect() may have completed while this
-                        // probe was in flight; a stale result must not clobber the state
-                        // of the session that is current now.
-                        if (get().client === client) {
-                            set({ scriptsSupported: root?.capabilities.scripts === true });
-                        }
-                    } catch {
-                        if (get().client === client) {
-                            set({ scriptsSupported: false });
-                        }
-                    }
+                    // Scripts tab visibility follows the gateway capability. Not
+                    // awaited: a gateway that answers /health and then hangs on
+                    // GET / must not stall entity loading behind this probe -
+                    // that is exactly the "connected over an empty tree" state
+                    // this is meant to avoid. It still carries its own 5s
+                    // timeout, and the client-identity guard below makes a late
+                    // (or stale, from a disconnect/reconnect mid-flight) result
+                    // safe to ignore.
+                    const capsController = new AbortController();
+                    const capsTimeout = setTimeout(() => capsController.abort(), 5000);
+                    void client
+                        .GET('/', { signal: capsController.signal })
+                        .then(({ data: root }) => {
+                            if (get().client === client) {
+                                set({ scriptsSupported: root?.capabilities.scripts === true });
+                            }
+                        })
+                        .catch(() => {
+                            if (get().client === client) {
+                                set({ scriptsSupported: false });
+                            }
+                        })
+                        .finally(() => clearTimeout(capsTimeout));
 
                     // Load root entities after successful connection
                     await get().loadRootEntities();
@@ -2053,10 +2056,11 @@ export const useAppStore = create<AppState>()(
                     request
                 );
                 if (error) throw toScriptsApiError(error, response?.status ?? 0);
+                const execution = toScriptExecution(data);
 
                 const key = scriptEntityKey(entityType, entityId);
                 const record: ScriptExecutionRecord = {
-                    execution: data as ScriptExecution,
+                    execution,
                     scriptId: script.id,
                     scriptName: script.name,
                     entityType,
@@ -2085,13 +2089,14 @@ export const useAppStore = create<AppState>()(
                     action
                 );
                 if (error) throw toScriptsApiError(error, response?.status ?? 0);
+                const execution = toScriptExecution(data);
 
                 const key = scriptEntityKey(entityType, entityId);
                 const existing = get()
                     .scriptExecutions.get(key)
                     ?.find((r) => r.execution.id === executionId);
                 if (existing) {
-                    const record: ScriptExecutionRecord = { ...existing, execution: data as ScriptExecution };
+                    const record: ScriptExecutionRecord = { ...existing, execution };
                     set({ scriptExecutions: upsertExecutionRecord(get().scriptExecutions, key, record) });
                     get().startScriptPolling();
                 }
@@ -2127,45 +2132,42 @@ export const useAppStore = create<AppState>()(
                 executionId: string
             ) => {
                 const { client } = get();
-                if (!client) return;
+                if (!client) throw new ScriptsApiError('Not connected', 0, '');
 
                 const key = scriptEntityKey(entityType, entityId);
-                try {
-                    const { data, error } = await getScriptExecution(
-                        client,
-                        entityType,
-                        entityId,
-                        scriptId,
-                        executionId
-                    );
-                    if (error) {
-                        // Only resource-not-found means the execution itself is gone.
-                        // entity-not-found means the entity is momentarily absent (a
-                        // node restarting under runtime discovery, for example) and
-                        // must not evict a record Refresh is meant to rescue.
-                        if (scriptErrorCode(error) === SCRIPT_ERROR_CODE.resourceNotFound) {
-                            set({ scriptExecutions: markExecutionLost(get().scriptExecutions, key, executionId) });
-                        }
+                const { data, error, response } = await getScriptExecution(
+                    client,
+                    entityType,
+                    entityId,
+                    scriptId,
+                    executionId
+                );
+                if (error) {
+                    // Only resource-not-found means the execution itself is gone -
+                    // mark it lost and treat that as the answer Refresh was
+                    // looking for, not a failure to surface.
+                    if (scriptErrorCode(error) === SCRIPT_ERROR_CODE.resourceNotFound) {
+                        set({ scriptExecutions: markExecutionLost(get().scriptExecutions, key, executionId) });
                         return;
                     }
-                    if (!data) return;
+                    // Anything else - entity-not-found (the entity is momentarily
+                    // absent, e.g. a node restarting under runtime discovery, and
+                    // must not evict a record Refresh is meant to rescue), a 500,
+                    // a network error - must reach the caller so the card's
+                    // "Failed to refresh" toast can fire.
+                    throw toScriptsApiError(error, response?.status ?? 0);
+                }
+                const execution = toScriptExecution(data);
 
-                    const existing = get()
-                        .scriptExecutions.get(key)
-                        ?.find((r) => r.execution.id === executionId);
-                    if (existing) {
-                        // Clear `lost`: a successful refresh means the gateway answered,
-                        // so this is exactly the rescue path a lost record needs.
-                        const record: ScriptExecutionRecord = {
-                            ...existing,
-                            execution: data as ScriptExecution,
-                            lost: false,
-                        };
-                        set({ scriptExecutions: upsertExecutionRecord(get().scriptExecutions, key, record) });
-                        get().startScriptPolling();
-                    }
-                } catch (err) {
-                    console.error('[store] refreshScriptExecution failed', err);
+                const existing = get()
+                    .scriptExecutions.get(key)
+                    ?.find((r) => r.execution.id === executionId);
+                if (existing) {
+                    // Clear `lost`: a successful refresh means the gateway answered,
+                    // so this is exactly the rescue path a lost record needs.
+                    const record: ScriptExecutionRecord = { ...existing, execution, lost: false };
+                    set({ scriptExecutions: upsertExecutionRecord(get().scriptExecutions, key, record) });
+                    get().startScriptPolling();
                 }
             },
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -989,3 +989,50 @@ export interface UpdateEntry {
     id: string;
     status: UpdateStatus | null; // null = status fetch failed
 }
+
+// =============================================================================
+// Scripts
+// =============================================================================
+
+export type ScriptMetadata = components['schemas']['ScriptMetadata'];
+export type ScriptExecution = components['schemas']['ScriptExecution'];
+/** Wire wrapper of the list endpoint: {items, _links}. */
+export type ScriptList = components['schemas']['ScriptList'];
+export type ScriptUploadResponse = components['schemas']['ScriptUploadResponse'];
+
+/**
+ * Entity types exposing the scripts collection.
+ * The gateway registers script routes for apps and components only.
+ */
+export type ScriptEntityType = Extract<SovdResourceEntityType, 'apps' | 'components'>;
+
+/**
+ * Execution record tracked client-side. The gateway has no endpoint listing
+ * executions, so the UI remembers the ids it started. In-memory only.
+ */
+export interface ScriptExecutionRecord {
+    execution: ScriptExecution;
+    scriptId: string;
+    scriptName: string;
+    entityType: ScriptEntityType;
+    entityId: string;
+    /** Set when polling returned 404: the gateway no longer knows this execution. */
+    lost?: boolean;
+}
+
+export interface StartScriptExecutionRequest {
+    execution_type: string;
+    parameters?: Record<string, unknown>;
+    proximity_response?: string;
+}
+
+/** errorStatus lets the panel tell 501 from an empty list. */
+export interface ScriptsFetchResult {
+    items: ScriptMetadata[];
+    errorStatus?: number;
+}
+
+export interface ScriptUploadMetadata {
+    name?: string;
+    description?: string;
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -11,3 +11,52 @@ if (typeof Blob !== 'undefined' && !Blob.prototype.text) {
         });
     };
 }
+
+/**
+ * Recent Node versions ship an experimental global `localStorage` backed by a
+ * file that vitest-environment-jsdom's globals never get a chance to
+ * override, since it already occupies the slot before the environment is
+ * installed. Left in place, it throws "Cannot read properties of undefined
+ * (reading 'setItem')" the moment anything (e.g. zustand's persist
+ * middleware) touches it - jsdom's own window.localStorage works fine, it is
+ * only the copy merged onto the global object that is broken. Replace it
+ * with a minimal in-memory Storage only when it is actually broken, so this
+ * is a no-op on Node versions where jsdom's localStorage already works.
+ */
+function storageWorks(): boolean {
+    try {
+        globalThis.localStorage.setItem('__storage_probe__', '1');
+        globalThis.localStorage.removeItem('__storage_probe__');
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+if (!storageWorks()) {
+    class MemoryStorage implements Storage {
+        private readonly store = new Map<string, string>();
+        get length(): number {
+            return this.store.size;
+        }
+        clear(): void {
+            this.store.clear();
+        }
+        getItem(key: string): string | null {
+            return this.store.has(key) ? this.store.get(key)! : null;
+        }
+        key(index: number): string | null {
+            return Array.from(this.store.keys())[index] ?? null;
+        }
+        removeItem(key: string): void {
+            this.store.delete(key);
+        }
+        setItem(key: string, value: string): void {
+            this.store.set(key, String(value));
+        }
+    }
+
+    for (const prop of ['localStorage', 'sessionStorage'] as const) {
+        Object.defineProperty(globalThis, prop, { configurable: true, value: new MemoryStorage() });
+    }
+}


### PR DESCRIPTION
# Pull Request

## Summary

Adds a Scripts tab to the entity view: list the diagnostic scripts available on an entity, run one with parameters, follow its status, stop or force-kill it, upload a script file or write one in the browser, and delete scripts that are no longer needed.

The tab appears only when the gateway reports `capabilities.scripts` in `GET /`, and only on apps and components, which are the entity types the gateway registers script routes for.

Three commits, each of which builds on its own: the domain layer with the gateway helpers and the store wiring, the user interface, and one unrelated fix explained below.

**Notable behaviour, because the gateway shapes it:**

- The gateway has no endpoint listing executions, so the UI remembers the ids it starts and one interval in the store polls them. Execution history is in-memory: reloading the page during a long run loses the ability to stop it. Trimming that history never drops an execution that is still active, since losing its id would orphan the process for good.
- Parameters reach an uploaded script as JSON on stdin, never as arguments. Only manifest entries declaring `args` get command-line arguments. The starter template in the editor shows this, because it is the least guessable part of writing a first script.
- A script's output appears when it finishes, not while it runs, and the gateway discards stdout entirely when a script exits non-zero, leaving stderr and the exit code.
- A stopped execution is not a failure. The gateway fills in an error message on a successful stop, on a force-kill and on a timeout, so the card renders those as stopped rather than as an error.
- The uploaded file name selects the interpreter: `.py` runs under python3, `.bash` under bash, anything else under sh. That is why the file name is a required field in the editor and why the hint sits under it.

**Limitations worth knowing before review:**

- `src/lib/api-dispatch.ts` carries two documented `as unknown as` casts. The gateway's OpenAPI spec declares the start-execution body as a bare `type: object` and the multipart upload body as a free-form object, so the generated client types them as `Record<string, never>` and an index signature. The runtime payloads are correct; fixing this properly means correcting the spec in the gateway.
- Stopping a script sets the status to terminated as soon as the signal is sent. A script that traps SIGTERM keeps running, and the gateway rejects further control actions on an execution it already considers finished, so the interface cannot offer a way out. This is a gateway-side limitation.
- Scripts written or uploaded from the browser cannot carry a parameters schema, so they always get the raw JSON editor rather than a generated form. The wire format supports it; the interface does not expose it yet.
- Marking an execution as no longer tracked is narrowed to the gateway saying the execution is gone, not the entity. An entity that disappears permanently therefore keeps its execution polled once a second and shown as running. It is bounded to background requests, pauses while the tab is hidden, and clears on reload; closing it needs an eviction policy that belongs in its own change.
- `npm run typecheck` checks nothing in this repository: the root config has `"files": []` and `tsc --noEmit` ignores project references. `npm run build` runs `tsc -b` and is the real gate. This is now stated in CONTRIBUTING (in the follow-up).
- Playwright ships as a development dependency here, ahead of the follow-up that adds the end-to-end harness.

`src/App.tsx` carries a fix unrelated to scripts, kept in its own commit: the stored server URL was passed to `connect()` from inside a `setTimeout`, and Strict Mode's mount-cleanup-remount cycle cleared that timer before it fired, so a persisted URL never reconnected in development. It surfaced while building the end-to-end harness, which depends on that reconnect.

---

## Issue

- closes #45

---

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

576 unit tests, 28 files. The domain layer, the polling cycle, the dispatch helpers and all five components are covered, including the cases that are easy to get wrong: a progress bar at zero, a stopped execution rendered as stopped rather than failed, output that is only stdout versus output that is structured, the raw-JSON fallback for a schema that cannot become a form, and a parameter form that survives the once-a-second re-render while a script runs.

End-to-end coverage against a real gateway comes in the follow-up pull request, which builds on this branch. It exercises this feature: running a script and reading what it received on stdin, a failing script's exit code and stderr, stopping a long one, and writing a bash script and a python script in the browser and running them.

Manually: point the app at a gateway with `scripts.scripts_dir` configured. Without it the gateway reports no capability and the tab stays hidden, which is the intended behaviour.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Linting passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] Docs were updated if behavior or public API changed
